### PR TITLE
Make Slingshot `:provided`, offer a ns/API without it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,5 @@ jobs:
         uses: actions/checkout@v2-beta
       - name: Run tests
         run: lein with-profile -user,-dev,+test,+${{ matrix.clojure-version }} do clean, test
+      - name: Lint
+        run: lein with-profile -user,-dev,+test,+${{ matrix.clojure-version }} eastwood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### unreleased
-Update to support self-signed certificates via insecure? option
+
+- Offer a new client ns: `clj-http-lite.client`
+  - Unlike its `clj-http.lite.client` predecessor, it doesn't use the Slingshot library, using vanilla `throw`/`ex-info` instead.
+- Make the `slingshot` artifact dependency provided
+  - If you intend to use the old `clj-http.lite.client` (or some transitive dep is using it), please add `[slingshot "0.12.2"]` expicitly in your project.
+- Support self-signed certificates via `insecure?` option
 
 ### 0.4.3
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # `clj-http-lite` [![cljdoc badge](https://cljdoc.xyz/badge/org.martinklepsch/clj-http-lite)](https://cljdoc.xyz/d/org.martinklepsch/clj-http-lite/CURRENT) [![CI](https://github.com/martinklepsch/clj-http-lite/workflows/Tests/badge.svg)](https://github.com/martinklepsch/clj-http-lite/actions)
 
-A Clojure HTTP library similar to [clj-http](http://github.com/dakrone/clj-http), but more lightweight. Compatible with GraalVM.
+A Clojure HTTP library similar to [clj-http](http://github.com/dakrone/clj-http), but more lightweight (and dependency-free by default). Compatible with GraalVM.
 
 > This is a somewhat maintained fork of the original [`hiredman/clj-http-lite`](https://github.com/hiredman/clj-http-lite) repo.
 
@@ -27,10 +27,10 @@ A Clojure HTTP library similar to [clj-http](http://github.com/dakrone/clj-http)
 ## Usage
 
 The main HTTP client functionality is provided by the
-`clj-http.lite.client` namespace:
+`clj-http-lite.client` namespace:
 
 ```clojure
-(require '[clj-http.lite.client :as client])
+(require '[clj-http-lite.client :as client])
 ```
 
 The client supports simple `get`, `head`, `put`, `post`, and `delete`
@@ -143,25 +143,19 @@ as a primitive for building higher-level interfaces:
 
 ### Exceptions
 
+> NOTE: The newer `clj-http-lite.client` ns does not use Slingshot.
+> The legacy `clj-http.lite.client` remains available, as long as your project explicitly adds a Slingshot dependency.
+
 The client will throw exceptions on, well, exceptional status
-codes. clj-http will throw a
-[Slingshot](http://github.com/scgilardi/slingshot) Stone that can be
-caught by a regular `(catch Exception e ...)` or in Slingshot's `try+`
-block:
+codes. clj-http will `throw` a vanilla `ex-info`.
 
 ```clojure
 (client/get "http://site.com/broken")
-=> Stone Object thrown by throw+: {:status 404, :headers {"server" "nginx/1.0.4",
-                                                          "x-runtime" "12ms",
-                                                          "content-encoding" "gzip",
-                                                          "content-type" "text/html; charset=utf-8",
-                                                          "date" "Mon, 17 Oct 2011 23:15 :36 GMT",
-                                                          "cache-control" "no-cache",
-                                                          "status" "404 Not Found",
-                                                          "transfer-encoding" "chunked",
-                                                          "connection" "close"},
-                                   :body "...body here..."}
-   clj-http.lite.client/wrap-exceptions/fn--227 (client.clj:37)
+#error {
+ :cause "clj-http: status 404"
+ :data {:response {:headers {"content-type" "text/html; charset=UTF-8", "content-length" "1569"},
+                   :status 404,
+                   :body "..."}}}
 
 ;; You can also ignore exceptions and handle them yourself:
 (client/get "http://site.com/broken" {:throw-exceptions false})
@@ -210,10 +204,10 @@ server applications.
 
 The client in `clj-http.lite.core` makes HTTP requests according to a given
 Ring request map and returns Ring response maps corresponding to the
-resulting HTTP response. The function `clj-http.lite.client/request` uses
+resulting HTTP response. The function `clj-http-lite.client/request` uses
 Ring-style middleware to layer functionality over the core HTTP
-request/response implementation. Methods like `clj-http.lite.client/get`
-are sugar over this `clj-http.lite.client/request` function.
+request/response implementation. Methods like `clj-http-lite.client/get`
+are sugar over this `clj-http-lite.client/request` function.
 
 ## Development
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
 (defproject org.martinklepsch/clj-http-lite "0.4.3"
-  :description "A Clojure HTTP library similar to clj-http, but more lightweight."
+  :description "A Clojure HTTP library similar to clj-http, but dependency-free."
   :url "https://github.com/martinklepsch/clj-http-lite/"
   :license {:name "MIT"
             :url "http://www.opensource.org/licenses/mit-license.php"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [slingshot "0.12.2"]]
+  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
+                 [slingshot "0.12.2" :scope "provided"]]
   :profiles {:test {:dependencies   [[ring/ring-jetty-adapter "1.3.2"]
                                      [ch.qos.logback/logback-classic "1.2.3"
                                       :exclusions [org.slf4j/slf4j-api]]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}}
+  :plugins [[jonase/eastwood "0.9.9"]]
   :test-selectors {:default     (constantly true)
                    :all         (constantly true)
                    :unit        #(not (:integration %))

--- a/src/clj_http/lite/client.clj
+++ b/src/clj_http/lite/client.clj
@@ -1,34 +1,78 @@
 (ns clj-http.lite.client
-  "Batteries-included HTTP client."
-  (:require [clojure.string :as str]
-            [clojure.java.io :as io]
-            [clj-http.lite.core :as core]
+  "Batteries-included HTTP client.
+
+  NOTE: this ns is based on the Slingshot library.
+
+  If you want a Slingshot-free ns / API instead, please use the newer `clj-http.lite.client`"
+  (:require [clj-http-lite.client :as original]
             [clj-http.lite.links :refer [wrap-links]]
-            [clj-http.lite.util :as util]
+            [clj-http-lite.impl :refer [copy]]
             [slingshot.slingshot :refer [throw+]])
-  (:import (java.io InputStream File)
-           (java.net URL UnknownHostException))
   (:refer-clojure :exclude (get update)))
 
 (set! *warn-on-reflection* true)
 
-(defn update [m k f & args]
-  (assoc m k (apply f (m k) args)))
+(copy original/update)
 
-(defn when-pos [v]
-  (when (and v (pos? v)) v))
+(copy original/when-pos)
 
-(defn parse-url [url]
-  (let [url-parsed (io/as-url url)]
-    {:scheme (keyword (.getProtocol url-parsed))
-     :server-name (.getHost url-parsed)
-     :server-port (when-pos (.getPort url-parsed))
-     :uri (.getPath url-parsed)
-     :user-info (.getUserInfo url-parsed)
-     :query-string (.getQuery url-parsed)}))
+(copy original/parse-url)
 
-(def unexceptional-status?
-  #{200 201 202 203 204 205 206 207 300 301 302 303 307})
+(copy original/unexceptional-status?)
+
+(copy original/follow-redirect)
+
+(copy original/wrap-redirects)
+
+(copy original/wrap-decompression)
+
+(copy original/wrap-output-coercion)
+
+(copy original/wrap-input-coercion)
+
+(copy original/content-type-value)
+
+(copy original/wrap-content-type)
+
+(copy original/wrap-accept)
+
+(copy original/accept-encoding-value)
+
+(copy original/wrap-accept-encoding)
+
+(copy original/generate-query-string)
+
+(copy original/wrap-query-params)
+
+(copy original/basic-auth-value)
+
+(copy original/wrap-basic-auth)
+
+(copy original/parse-user-info)
+
+(copy original/wrap-user-info)
+
+(copy original/wrap-method)
+
+(copy original/wrap-form-params)
+
+(copy original/wrap-url)
+
+(copy original/wrap-unknown-host)
+
+(copy original/request)
+
+(copy original/get)
+
+(copy original/head)
+
+(copy original/post)
+
+(copy original/put)
+
+(copy original/delete)
+
+(copy original/with-connection-pool)
 
 (defn wrap-exceptions [client]
   (fn [req]
@@ -37,192 +81,6 @@
               (unexceptional-status? status))
         resp
         (throw+ resp "clj-http: status %s" (:status %))))))
-
-(declare wrap-redirects)
-
-(defn follow-redirect [client req resp]
-  (let [url (get-in resp [:headers "location"])]
-    ((wrap-redirects client) (assoc req :url url))))
-
-(defn wrap-redirects [client]
-  (fn [{:keys [request-method follow-redirects] :as req}]
-    (let [{:keys [status] :as resp} (client req)]
-      (cond
-       (= false follow-redirects)
-       resp
-       (and (#{301 302 307} status) (#{:get :head} request-method))
-       (follow-redirect client req resp)
-       (and (= 303 status) (= :head request-method))
-       (follow-redirect client (assoc req :request-method :get) resp)
-       :else
-       resp))))
-
-(defn wrap-decompression [client]
-  (fn [req]
-    (if (get-in req [:headers "Accept-Encoding"])
-      (client req)
-      (let [req-c (update req :headers assoc "Accept-Encoding" "gzip, deflate")
-            resp-c (client req-c)]
-        (case (or (get-in resp-c [:headers "Content-Encoding"])
-                  (get-in resp-c [:headers "content-encoding"]))
-          "gzip" (update resp-c :body util/gunzip)
-          "deflate" (update resp-c :body util/inflate)
-          resp-c)))))
-
-(defn wrap-output-coercion [client]
-  (fn [{:keys [as] :as req}]
-    (let [{:keys [body] :as resp} (client req)]
-      (if body
-        (cond
-         (keyword? as)
-         (condp = as
-           ;; Don't do anything for streams
-           :stream resp
-           ;; Don't do anything when it's a byte-array
-           :byte-array resp
-           ;; Automatically determine response type
-           :auto
-           (assoc resp
-             :body
-             (let [typestring (get-in resp [:headers "content-type"])]
-               (cond
-                (.startsWith (str typestring) "text/")
-                (if-let [charset (second (re-find #"charset=(.*)"
-                                                  (str typestring)))]
-                  (String. #^"[B" body ^String charset)
-                  (String. #^"[B" body "UTF-8"))
-
-                :else
-                (String. #^"[B" body "UTF-8"))))
-           ;; No :as matches found
-           (assoc resp :body (String. #^"[B" body "UTF-8")))
-         ;; Try the charset given if a string is specified
-         (string? as)
-         (assoc resp :body (String. #^"[B" body ^String as))
-         ;; Return a regular UTF-8 string body
-         :else
-         (assoc resp :body (String. #^"[B" body "UTF-8")))
-        resp))))
-
-(defn wrap-input-coercion [client]
-  (fn [{:keys [body body-encoding length] :as req}]
-    (if body
-      (cond
-       (string? body)
-       (client (-> req (assoc :body (.getBytes ^String body)
-                              :character-encoding (or body-encoding
-                                                      "UTF-8"))))
-       :else
-       (client req))
-      (client req))))
-
-(defn content-type-value [type]
-  (if (keyword? type)
-    (str "application/" (name type))
-    type))
-
-(defn wrap-content-type [client]
-  (fn [{:keys [content-type] :as req}]
-    (if content-type
-      (client (-> req (assoc :content-type
-                        (content-type-value content-type))))
-      (client req))))
-
-(defn wrap-accept [client]
-  (fn [{:keys [accept] :as req}]
-    (if accept
-      (client (-> req (dissoc :accept)
-                  (assoc-in [:headers "Accept"]
-                            (content-type-value accept))))
-      (client req))))
-
-(defn accept-encoding-value [accept-encoding]
-  (str/join ", " (map name accept-encoding)))
-
-(defn wrap-accept-encoding [client]
-  (fn [{:keys [accept-encoding] :as req}]
-    (if accept-encoding
-      (client (-> req (dissoc :accept-encoding)
-                  (assoc-in [:headers "Accept-Encoding"]
-                            (accept-encoding-value accept-encoding))))
-      (client req))))
-
-(defn generate-query-string [params]
-  (str/join "&"
-            (mapcat (fn [[k v]]
-                      (if (sequential? v)
-                        (map #(str (util/url-encode (name %1))
-                                   "="
-                                   (util/url-encode (str %2)))
-                             (repeat k) v)
-                        [(str (util/url-encode (name k))
-                              "="
-                              (util/url-encode (str v)))]))
-                    params)))
-
-(defn wrap-query-params [client]
-  (fn [{:keys [query-params] :as req}]
-    (if query-params
-      (client (-> req (dissoc :query-params)
-                  (assoc :query-string
-                    (generate-query-string query-params))))
-      (client req))))
-
-(defn basic-auth-value [basic-auth]
-  (let [basic-auth (if (string? basic-auth)
-                     basic-auth
-                     (str (first basic-auth) ":" (second basic-auth)))]
-    (str "Basic " (util/base64-encode (util/utf8-bytes basic-auth)))))
-
-(defn wrap-basic-auth [client]
-  (fn [req]
-    (if-let [basic-auth (:basic-auth req)]
-      (client (-> req (dissoc :basic-auth)
-                  (assoc-in [:headers "Authorization"]
-                            (basic-auth-value basic-auth))))
-      (client req))))
-
-(defn parse-user-info [user-info]
-  (when user-info
-    (str/split user-info #":")))
-
-(defn wrap-user-info [client]
-  (fn [req]
-    (if-let [[user password] (parse-user-info (:user-info req))]
-      (client (assoc req :basic-auth [user password]))
-      (client req))))
-
-(defn wrap-method [client]
-  (fn [req]
-    (if-let [m (:method req)]
-      (client (-> req (dissoc :method)
-                  (assoc :request-method m)))
-      (client req))))
-
-(defn wrap-form-params [client]
-  (fn [{:keys [form-params request-method] :as req}]
-    (if (and form-params (= :post request-method))
-      (client (-> req
-                  (dissoc :form-params)
-                  (assoc :content-type (content-type-value
-                                        :x-www-form-urlencoded)
-                         :body (generate-query-string form-params))))
-      (client req))))
-
-(defn wrap-url [client]
-  (fn [req]
-    (if-let [url (:url req)]
-      (client (-> req (dissoc :url) (merge (parse-url url))))
-      (client req))))
-
-(defn wrap-unknown-host [client]
-  (fn [{:keys [ignore-unknown-host?] :as req}]
-    (try
-      (client req)
-      (catch UnknownHostException e
-        (if ignore-unknown-host?
-          nil
-          (throw e))))))
 
 (defn wrap-request
   "Returns a battaries-included HTTP request function coresponding to the given
@@ -245,58 +103,3 @@
       wrap-method
       wrap-links
       wrap-unknown-host))
-
-(def #^{:doc
-        "Executes the HTTP request corresponding to the given map and returns
-   the response map for corresponding to the resulting HTTP response.
-
-   In addition to the standard Ring request keys, the following keys are also
-   recognized:
-   * :url
-   * :method
-   * :query-params
-   * :basic-auth
-   * :content-type
-   * :accept
-   * :accept-encoding
-   * :as
-
-  The following additional behaviors over also automatically enabled:
-   * Exceptions are thrown for status codes other than 200-207, 300-303, or 307
-   * Gzip and deflate responses are accepted and decompressed
-   * Input and output bodies are coerced as required and indicated by the :as
-     option."}
-  request
-  (wrap-request #'core/request))
-
-(defn get
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req]]
-  (request (merge req {:method :get :url url})))
-
-(defn head
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req]]
-  (request (merge req {:method :head :url url})))
-
-(defn post
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req]]
-  (request (merge req {:method :post :url url})))
-
-(defn put
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req]]
-  (request (merge req {:method :put :url url})))
-
-(defn delete
-  "Like #'request, but sets the :method and :url as appropriate."
-  [url & [req]]
-  (request (merge req {:method :delete :url url})))
-
-(defmacro with-connection-pool
-  "This macro is a no-op, but left in to support backward-compatibility
-  with clj-http."
-  [opts & body]
-  `(do
-     ~@body))

--- a/src/clj_http_lite/client.clj
+++ b/src/clj_http_lite/client.clj
@@ -1,0 +1,304 @@
+(ns clj-http-lite.client
+  "Batteries-included HTTP client.
+
+  Replaces the older `clj-http.lite.client` ns which uses Slingshot.
+
+  This ns's API uses vanilla `throw` and `ex-info` instead."
+  (:require [clojure.string :as str]
+            [clojure.java.io :as io]
+            [clj-http.lite.core :as core]
+            [clj-http.lite.links :refer [wrap-links]]
+            [clj-http.lite.util :as util])
+  (:import (java.io InputStream File)
+           (java.net URL UnknownHostException))
+  (:refer-clojure :exclude (get update)))
+
+(defn update [m k f & args]
+  (assoc m k (apply f (m k) args)))
+
+(defn when-pos [v]
+  (when (and v (pos? v)) v))
+
+(defn parse-url [url]
+  (let [url-parsed (io/as-url url)]
+    {:scheme       (keyword (.getProtocol url-parsed))
+     :server-name  (.getHost url-parsed)
+     :server-port  (when-pos (.getPort url-parsed))
+     :uri          (.getPath url-parsed)
+     :user-info    (.getUserInfo url-parsed)
+     :query-string (.getQuery url-parsed)}))
+
+(def unexceptional-status?
+  #{200 201 202 203 204 205 206 207 300 301 302 303 307})
+
+(defn wrap-exceptions [client]
+  (fn [req]
+    (let [{:keys [status] :as resp} (client req)]
+      (if (or (not (clojure.core/get req :throw-exceptions true))
+              (unexceptional-status? status))
+        resp
+        (throw (ex-info (format "clj-http: status %s" (:status resp))
+                        {:response resp}))))))
+
+(declare wrap-redirects)
+
+(defn follow-redirect [client req resp]
+  (let [url (get-in resp [:headers "location"])]
+    ((wrap-redirects client) (assoc req :url url))))
+
+(defn wrap-redirects [client]
+  (fn [{:keys [request-method follow-redirects] :as req}]
+    (let [{:keys [status] :as resp} (client req)]
+      (cond
+        (= false follow-redirects)
+        resp
+        (and (#{301 302 307} status) (#{:get :head} request-method))
+        (follow-redirect client req resp)
+        (and (= 303 status) (= :head request-method))
+        (follow-redirect client (assoc req :request-method :get) resp)
+        :else
+        resp))))
+
+(defn wrap-decompression [client]
+  (fn [req]
+    (if (get-in req [:headers "Accept-Encoding"])
+      (client req)
+      (let [req-c (update req :headers assoc "Accept-Encoding" "gzip, deflate")
+            resp-c (client req-c)]
+        (case (or (get-in resp-c [:headers "Content-Encoding"])
+                  (get-in resp-c [:headers "content-encoding"]))
+          "gzip"    (update resp-c :body util/gunzip)
+          "deflate" (update resp-c :body util/inflate)
+          resp-c)))))
+
+(defn wrap-output-coercion [client]
+  (fn [{:keys [as] :as req}]
+    (let [{:keys [body] :as resp} (client req)]
+      (if body
+        (cond
+          (keyword? as)
+          (condp = as
+            ;; Don't do anything for streams
+            :stream     resp
+            ;; Don't do anything when it's a byte-array
+            :byte-array resp
+            ;; Automatically determine response type
+            :auto
+            (assoc resp
+                   :body
+                   (let [typestring (get-in resp [:headers "content-type"])]
+                     (cond
+                       (.startsWith (str typestring) "text/")
+                       (if-let [charset (second (re-find #"charset=(.*)"
+                                                         (str typestring)))]
+                         (String. #^"[B" body ^String charset)
+                         (String. #^"[B" body "UTF-8"))
+
+                       :else
+                       (String. #^"[B" body "UTF-8"))))
+            ;; No :as matches found
+            (assoc resp :body (String. #^"[B" body "UTF-8")))
+          ;; Try the charset given if a string is specified
+          (string? as)
+          (assoc resp :body (String. #^"[B" body ^String as))
+          ;; Return a regular UTF-8 string body
+          :else
+          (assoc resp :body (String. #^"[B" body "UTF-8")))
+        resp))))
+
+(defn wrap-input-coercion [client]
+  (fn [{:keys [body body-encoding length] :as req}]
+    (if body
+      (cond
+        (string? body)
+        (client (-> req (assoc :body               (.getBytes ^String body)
+                               :character-encoding (or body-encoding
+                                                       "UTF-8"))))
+        :else
+        (client req))
+      (client req))))
+
+(defn content-type-value [type]
+  (if (keyword? type)
+    (str "application/" (name type))
+    type))
+
+(defn wrap-content-type [client]
+  (fn [{:keys [content-type] :as req}]
+    (if content-type
+      (client (-> req (assoc :content-type
+                             (content-type-value content-type))))
+      (client req))))
+
+(defn wrap-accept [client]
+  (fn [{:keys [accept] :as req}]
+    (if accept
+      (client (-> req (dissoc :accept)
+                  (assoc-in [:headers "Accept"]
+                            (content-type-value accept))))
+      (client req))))
+
+(defn accept-encoding-value [accept-encoding]
+  (str/join ", " (map name accept-encoding)))
+
+(defn wrap-accept-encoding [client]
+  (fn [{:keys [accept-encoding] :as req}]
+    (if accept-encoding
+      (client (-> req (dissoc :accept-encoding)
+                  (assoc-in [:headers "Accept-Encoding"]
+                            (accept-encoding-value accept-encoding))))
+      (client req))))
+
+(defn generate-query-string [params]
+  (str/join "&"
+            (mapcat (fn [[k v]]
+                      (if (sequential? v)
+                        (map #(str (util/url-encode (name %1))
+                                   "="
+                                   (util/url-encode (str %2)))
+                             (repeat k) v)
+                        [(str (util/url-encode (name k))
+                              "="
+                              (util/url-encode (str v)))]))
+                    params)))
+
+(defn wrap-query-params [client]
+  (fn [{:keys [query-params] :as req}]
+    (if query-params
+      (client (-> req (dissoc :query-params)
+                  (assoc :query-string
+                         (generate-query-string query-params))))
+      (client req))))
+
+(defn basic-auth-value [basic-auth]
+  (let [basic-auth (if (string? basic-auth)
+                     basic-auth
+                     (str (first basic-auth) ":" (second basic-auth)))]
+    (str "Basic " (util/base64-encode (util/utf8-bytes basic-auth)))))
+
+(defn wrap-basic-auth [client]
+  (fn [req]
+    (if-let [basic-auth (:basic-auth req)]
+      (client (-> req (dissoc :basic-auth)
+                  (assoc-in [:headers "Authorization"]
+                            (basic-auth-value basic-auth))))
+      (client req))))
+
+(defn parse-user-info [user-info]
+  (when user-info
+    (str/split user-info #":")))
+
+(defn wrap-user-info [client]
+  (fn [req]
+    (if-let [[user password] (parse-user-info (:user-info req))]
+      (client (assoc req :basic-auth [user password]))
+      (client req))))
+
+(defn wrap-method [client]
+  (fn [req]
+    (if-let [m (:method req)]
+      (client (-> req (dissoc :method)
+                  (assoc :request-method m)))
+      (client req))))
+
+(defn wrap-form-params [client]
+  (fn [{:keys [form-params request-method] :as req}]
+    (if (and form-params (= :post request-method))
+      (client (-> req
+                  (dissoc :form-params)
+                  (assoc :content-type (content-type-value
+                                        :x-www-form-urlencoded)
+                         :body         (generate-query-string form-params))))
+      (client req))))
+
+(defn wrap-url [client]
+  (fn [req]
+    (if-let [url (:url req)]
+      (client (-> req (dissoc :url) (merge (parse-url url))))
+      (client req))))
+
+(defn wrap-unknown-host [client]
+  (fn [{:keys [ignore-unknown-host?] :as req}]
+    (try
+      (client req)
+      (catch UnknownHostException e
+        (if ignore-unknown-host?
+          nil
+          (throw e))))))
+
+(defn wrap-request
+  "Returns a battaries-included HTTP request function coresponding to the given
+   core client. See client/client."
+  [request]
+  (-> request
+      wrap-query-params
+      wrap-user-info
+      wrap-url
+      wrap-redirects
+      wrap-decompression
+      wrap-input-coercion
+      wrap-output-coercion
+      wrap-exceptions
+      wrap-basic-auth
+      wrap-accept
+      wrap-accept-encoding
+      wrap-content-type
+      wrap-form-params
+      wrap-method
+      wrap-links
+      wrap-unknown-host))
+
+(def #^{:doc
+        "Executes the HTTP request corresponding to the given map and returns
+   the response map for corresponding to the resulting HTTP response.
+
+   In addition to the standard Ring request keys, the following keys are also
+   recognized:
+   * :url
+   * :method
+   * :query-params
+   * :basic-auth
+   * :content-type
+   * :accept
+   * :accept-encoding
+   * :as
+
+  The following additional behaviors over also automatically enabled:
+   * Exceptions are thrown for status codes other than 200-207, 300-303, or 307
+   * Gzip and deflate responses are accepted and decompressed
+   * Input and output bodies are coerced as required and indicated by the :as
+     option."}
+  request
+  (wrap-request #'core/request))
+
+(defn get
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :get :url url})))
+
+(defn head
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :head :url url})))
+
+(defn post
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :post :url url})))
+
+(defn put
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :put :url url})))
+
+(defn delete
+  "Like #'request, but sets the :method and :url as appropriate."
+  [url & [req]]
+  (request (merge req {:method :delete :url url})))
+
+(defmacro with-connection-pool
+  "This macro is a no-op, but left in to support backward-compatibility
+  with clj-http."
+  [opts & body]
+  `(do
+     ~@body))

--- a/src/clj_http_lite/impl.clj
+++ b/src/clj_http_lite/impl.clj
@@ -1,0 +1,25 @@
+(ns clj-http-lite.impl
+  (:require
+   [clojure.walk :as walk]))
+
+(defmacro copy
+  "`def`ines a value based on a var from another namespace,
+  keeping its metadata (especially `:docstring`, `:arglists`)
+  while discarding metadata that tends to be unique per ns.
+
+  Similar to Potemkin's `import-vars` but leaner, and more correct when it comes to metadata."
+  [x]
+  {:pre [(and (symbol? x)
+              (namespace x))]}
+  (let [ref (-> x resolve (doto assert))
+        m (walk/postwalk (fn [x]
+                           (if (seq? x)
+                             (list 'quote x)
+                             x))
+                         (-> ref meta (dissoc :file :line :column :ns)))
+        s (-> x
+              name
+              symbol
+              (with-meta m))]
+    `(def ~s
+       (deref ~ref))))

--- a/test/clj_http/test/client.clj
+++ b/test/clj_http/test/client.clj
@@ -1,22 +1,77 @@
 (ns clj-http.test.client
-  (:require [clj-http.lite.client :as client]
+  (:require [clj-http.lite.client :as sut.legacy]
+            [clj-http-lite.client :as sut]
             [clj-http.test.core :refer [base-req current-port with-server]]
             [clj-http.lite.util :as util]
-            [clojure.test :refer [deftest is testing use-fixtures]])
+            [clojure.test :refer [join-fixtures deftest is testing use-fixtures]])
   (:import (java.net UnknownHostException)
            (java.util Arrays)))
 
-(use-fixtures :each with-server)
+(def ^:dynamic *wrap-url*)
+(def ^:dynamic *parse-url*)
+(def ^:dynamic *request*)
+(def ^:dynamic *wrap-redirects*)
+(def ^:dynamic *wrap-exceptions*)
+(def ^:dynamic *wrap-decompression*)
+(def ^:dynamic *wrap-accept*)
+(def ^:dynamic *wrap-accept-encoding*)
+(def ^:dynamic *wrap-input-coercion*)
+(def ^:dynamic *wrap-output-coercion*)
+(def ^:dynamic *wrap-content-type*)
+(def ^:dynamic *wrap-method* nil)
+(def ^:dynamic *wrap-query-params*)
+(def ^:dynamic *wrap-form-params*)
+(def ^:dynamic *wrap-basic-auth*)
+(def ^:dynamic *get*)
+
+(def once-per-client (bound-fn [t]
+                       (binding [*wrap-url* sut.legacy/wrap-url
+                                 *parse-url* sut.legacy/parse-url
+                                 *request* sut.legacy/request
+                                 *wrap-redirects* sut.legacy/wrap-redirects
+                                 *wrap-exceptions* sut.legacy/wrap-exceptions
+                                 *wrap-decompression* sut.legacy/wrap-decompression
+                                 *wrap-accept* sut.legacy/wrap-accept
+                                 *wrap-accept-encoding* sut.legacy/wrap-accept-encoding
+                                 *wrap-input-coercion* sut.legacy/wrap-input-coercion
+                                 *wrap-output-coercion* sut.legacy/wrap-output-coercion
+                                 *wrap-content-type* sut.legacy/wrap-content-type
+                                 *wrap-method* sut.legacy/wrap-method
+                                 *wrap-query-params* sut.legacy/wrap-query-params
+                                 *wrap-form-params* sut.legacy/wrap-form-params
+                                 *wrap-basic-auth* sut.legacy/wrap-basic-auth
+                                 *get* sut.legacy/get]
+                         (t))
+
+                       (binding [*wrap-url* sut/wrap-url
+                                 *parse-url* sut/parse-url
+                                 *request* sut/request
+                                 *wrap-redirects* sut/wrap-redirects
+                                 *wrap-exceptions* sut/wrap-exceptions
+                                 *wrap-decompression* sut/wrap-decompression
+                                 *wrap-accept* sut/wrap-accept
+                                 *wrap-accept-encoding* sut/wrap-accept-encoding
+                                 *wrap-input-coercion* sut/wrap-input-coercion
+                                 *wrap-output-coercion* sut/wrap-output-coercion
+                                 *wrap-content-type* sut/wrap-content-type
+                                 *wrap-method* sut/wrap-method
+                                 *wrap-query-params* sut/wrap-query-params
+                                 *wrap-form-params* sut/wrap-form-params
+                                 *wrap-basic-auth* sut/wrap-basic-auth
+                                 *get* sut/get]
+                         (t))))
+
+(use-fixtures :each (join-fixtures [once-per-client with-server]))
 
 (deftest ^{:integration true} roundtrip
   ;; roundtrip with scheme as a keyword
-  (let [resp (client/request (merge (base-req) {:uri "/get" :method :get}))]
+  (let [resp (*request* (merge (base-req) {:uri "/get" :method :get}))]
     (is (= 200 (:status resp)))
     (is (= "get" (:body resp))))
   ;; roundtrip with scheme as a string
-  (let [resp (client/request (merge (base-req) {:uri    "/get"
-                                                :method :get
-                                                :scheme "http"}))]
+  (let [resp (*request* (merge (base-req) {:uri    "/get"
+                                           :method :get
+                                           :scheme "http"}))]
     (is (= 200 (:status resp)))
     (is (= "get" (:body resp)))))
 
@@ -31,11 +86,11 @@
 (deftest redirect-on-get
   (let [client (fn [req]
                  (if (= "foo.com" (:server-name req))
-                   {:status 302
+                   {:status  302
                     :headers {"location" "http://bar.com/bat"}}
                    {:status 200
-                    :req req}))
-        r-client (-> client client/wrap-url client/wrap-redirects)
+                    :req    req}))
+        r-client (-> client *wrap-url* *wrap-redirects*)
         resp (r-client {:server-name "foo.com" :request-method :get})]
     (is (= 200 (:status resp)))
     (is (= :get (:request-method (:req resp))))
@@ -46,11 +101,11 @@
 (deftest redirect-to-get-on-head
   (let [client (fn [req]
                  (if (= "foo.com" (:server-name req))
-                   {:status 303
+                   {:status  303
                     :headers {"location" "http://bar.com/bat"}}
                    {:status 200
-                    :req req}))
-        r-client (-> client client/wrap-url client/wrap-redirects)
+                    :req    req}))
+        r-client (-> client *wrap-url* *wrap-redirects*)
         resp (r-client {:server-name "foo.com" :request-method :head})]
     (is (= 200 (:status resp)))
     (is (= :get (:request-method (:req resp))))
@@ -59,33 +114,33 @@
 
 (deftest pass-on-non-redirect
   (let [client (fn [req] {:status 200 :body (:body req)})
-        r-client (client/wrap-redirects client)
+        r-client (*wrap-redirects* client)
         resp (r-client {:body "ok"})]
     (is (= 200 (:status resp)))
     (is (= "ok" (:body resp)))))
 
 (deftest pass-on-follow-redirects-false
   (let [client (fn [req] {:status 302 :body (:body req)})
-        r-client (client/wrap-redirects client)
+        r-client (*wrap-redirects* client)
         resp (r-client {:body "ok" :follow-redirects false})]
     (is (= 302 (:status resp)))
     (is (= "ok" (:body resp)))))
 
 (deftest throw-on-exceptional
   (let [client (fn [req] {:status 500})
-        e-client (client/wrap-exceptions client)]
+        e-client (*wrap-exceptions* client)]
     (is (thrown-with-msg? Exception #"500"
-          (e-client {})))))
+                          (e-client {})))))
 
 (deftest pass-on-non-exceptional
   (let [client (fn [req] {:status 200})
-        e-client (client/wrap-exceptions client)
+        e-client (*wrap-exceptions* client)
         resp (e-client {})]
     (is (= 200 (:status resp)))))
 
 (deftest pass-on-exceptional-when-surpressed
   (let [client (fn [req] {:status 500})
-        e-client (client/wrap-exceptions client)
+        e-client (*wrap-exceptions* client)
         resp (e-client {:throw-exceptions false})]
     (is (= 500 (:status resp)))))
 
@@ -93,9 +148,9 @@
   (let [client (fn [req]
                  (is (= "gzip, deflate"
                         (get-in req [:headers "Accept-Encoding"])))
-                 {:body (util/gzip (util/utf8-bytes "foofoofoo"))
+                 {:body    (util/gzip (util/utf8-bytes "foofoofoo"))
                   :headers {"Content-Encoding" "gzip"}})
-        c-client (client/wrap-decompression client)
+        c-client (*wrap-decompression* client)
         resp (c-client {})]
     (is (= "foofoofoo" (util/utf8-string (:body resp))))))
 
@@ -103,53 +158,53 @@
   (let [client (fn [req]
                  (is (= "gzip, deflate"
                         (get-in req [:headers "Accept-Encoding"])))
-                 {:body (util/deflate (util/utf8-bytes "barbarbar"))
+                 {:body    (util/deflate (util/utf8-bytes "barbarbar"))
                   :headers {"Content-Encoding" "deflate"}})
-        c-client (client/wrap-decompression client)
+        c-client (*wrap-decompression* client)
         resp (c-client {})]
     (is (= "barbarbar" (util/utf8-string (:body resp))))))
 
 (deftest pass-on-non-compressed
-  (let [c-client (client/wrap-decompression (fn [req] {:body "foo"}))
+  (let [c-client (*wrap-decompression* (fn [req] {:body "foo"}))
         resp (c-client {:uri "/foo"})]
     (is (= "foo" (:body resp)))))
 
 (deftest apply-on-accept
-  (is-applied client/wrap-accept
+  (is-applied *wrap-accept*
               {:accept :json}
               {:headers {"Accept" "application/json"}}))
 
 (deftest pass-on-no-accept
-  (is-passed client/wrap-accept
+  (is-passed *wrap-accept*
              {:uri "/foo"}))
 
 (deftest apply-on-accept-encoding
-  (is-applied client/wrap-accept-encoding
+  (is-applied *wrap-accept-encoding*
               {:accept-encoding [:identity :gzip]}
               {:headers {"Accept-Encoding" "identity, gzip"}}))
 
 (deftest pass-on-no-accept-encoding
-  (is-passed client/wrap-accept-encoding
+  (is-passed *wrap-accept-encoding*
              {:uri "/foo"}))
 
 (deftest apply-on-output-coercion
   (let [client (fn [req] {:body (util/utf8-bytes "foo")})
-        o-client (client/wrap-output-coercion client)
+        o-client (*wrap-output-coercion* client)
         resp (o-client {:uri "/foo"})]
     (is (= "foo" (:body resp)))))
 
 (deftest pass-on-no-output-coercion
   (let [client (fn [req] {:body nil})
-        o-client (client/wrap-output-coercion client)
+        o-client (*wrap-output-coercion* client)
         resp (o-client {:uri "/foo"})]
     (is (nil? (:body resp))))
   (let [client (fn [req] {:body :thebytes})
-        o-client (client/wrap-output-coercion client)
+        o-client (*wrap-output-coercion* client)
         resp (o-client {:uri "/foo" :as :byte-array})]
     (is (= :thebytes (:body resp)))))
 
 (deftest apply-on-input-coercion
-  (let [i-client (client/wrap-input-coercion identity)
+  (let [i-client (*wrap-input-coercion* identity)
         resp (i-client {:body "foo"})
         resp2 (i-client {:body "foo2" :body-encoding "ASCII"})
         data (slurp (:body resp))
@@ -160,52 +215,52 @@
     (is (= "foo2" data2))))
 
 (deftest pass-on-no-input-coercion
-  (is-passed client/wrap-input-coercion
+  (is-passed *wrap-input-coercion*
              {:body nil}))
 
 (deftest apply-on-content-type
-  (is-applied client/wrap-content-type
+  (is-applied *wrap-content-type*
               {:content-type :json}
               {:content-type "application/json"}))
 
 (deftest pass-on-no-content-type
-  (is-passed client/wrap-content-type
+  (is-passed *wrap-content-type*
              {:uri "/foo"}))
 
 (deftest apply-on-query-params
-  (is-applied client/wrap-query-params
+  (is-applied *wrap-query-params*
               {:query-params {"foo" "bar" "dir" "<<"}}
               {:query-string "foo=bar&dir=%3C%3C"}))
 
 (deftest pass-on-no-query-params
-  (is-passed client/wrap-query-params
+  (is-passed *wrap-query-params*
              {:uri "/foo"}))
 
 (deftest apply-on-basic-auth
-  (is-applied client/wrap-basic-auth
+  (is-applied *wrap-basic-auth*
               {:basic-auth ["Aladdin" "open sesame"]}
               {:headers {"Authorization"
                          "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="}}))
 
 (deftest pass-on-no-basic-auth
-  (is-passed client/wrap-basic-auth
+  (is-passed *wrap-basic-auth*
              {:uri "/foo"}))
 
 (deftest apply-on-method
-  (let [m-client (client/wrap-method identity)
+  (let [m-client (*wrap-method* identity)
         echo (m-client {:key :val :method :post})]
     (is (= :val (:key echo)))
     (is (= :post (:request-method echo)))
     (is (not (:method echo)))))
 
 (deftest pass-on-no-method
-  (let [m-client (client/wrap-method identity)
+  (let [m-client (*wrap-method* identity)
         echo (m-client {:key :val})]
     (is (= :val (:key echo)))
     (is (not (:request-method echo)))))
 
 (deftest apply-on-url
-  (let [u-client (client/wrap-url identity)
+  (let [u-client (*wrap-url* identity)
         resp (u-client {:url "http://google.com:8080/foo?bar=bat"})]
     (is (= :http (:scheme resp)))
     (is (= "google.com" (:server-name resp)))
@@ -214,42 +269,42 @@
     (is (= "bar=bat" (:query-string resp)))))
 
 (deftest pass-on-no-url
-  (let [u-client (client/wrap-url identity)
+  (let [u-client (*wrap-url* identity)
         resp (u-client {:uri "/foo"})]
     (is (= "/foo" (:uri resp)))))
 
 (deftest provide-default-port
-  (is (= nil  (-> "http://example.com/" client/parse-url :server-port)))
-  (is (= 8080 (-> "http://example.com:8080/" client/parse-url :server-port)))
-  (is (= nil  (-> "https://example.com/" client/parse-url :server-port)))
-  (is (= 8443 (-> "https://example.com:8443/" client/parse-url :server-port))))
+  (is (= nil  (-> "http://example.com/" *parse-url* :server-port)))
+  (is (= 8080 (-> "http://example.com:8080/" *parse-url* :server-port)))
+  (is (= nil  (-> "https://example.com/" *parse-url* :server-port)))
+  (is (= 8443 (-> "https://example.com:8443/" *parse-url* :server-port))))
 
 (deftest apply-on-form-params
   (testing "With form params"
-    (let [param-client (client/wrap-form-params identity)
+    (let [param-client (*wrap-form-params* identity)
           resp (param-client {:request-method :post
-                              :form-params {:param1 "value1"
-                                            :param2 "value2"}})]
+                              :form-params    {:param1 "value1"
+                                               :param2 "value2"}})]
       (is (or (= "param1=value1&param2=value2" (:body resp))
               (= "param2=value2&param1=value1" (:body resp))))
       (is (= "application/x-www-form-urlencoded" (:content-type resp)))
       (is (not (contains? resp :form-params)))))
   (testing "Ensure it does not affect GET requests"
-    (let [param-client (client/wrap-form-params identity)
+    (let [param-client (*wrap-form-params* identity)
           resp (param-client {:request-method :get
-                              :body "untouched"
-                              :form-params {:param1 "value1"
-                                            :param2 "value2"}})]
+                              :body           "untouched"
+                              :form-params    {:param1 "value1"
+                                               :param2 "value2"}})]
       (is (= "untouched" (:body resp)))
       (is (not (contains? resp :content-type)))))
 
   (testing "with no form params"
-    (let [param-client (client/wrap-form-params identity)
+    (let [param-client (*wrap-form-params* identity)
           resp (param-client {:body "untouched"})]
       (is (= "untouched" (:body resp)))
       (is (not (contains? resp :content-type))))))
 
 (deftest t-ignore-unknown-host
-  (is (thrown? UnknownHostException (client/get "http://aorecuf892983a.com")))
-  (is (nil? (client/get "http://aorecuf892983a.com"
-                        {:ignore-unknown-host? true}))))
+  (is (thrown? UnknownHostException (*get* "http://aorecuf892983a.com")))
+  (is (nil? (*get* "http://aorecuf892983a.com"
+                   {:ignore-unknown-host? true}))))

--- a/test/clj_http/test/cookies.clj
+++ b/test/clj_http/test/cookies.clj
@@ -1,6 +1,7 @@
-(ns clj-http.test.cookies
-  (:use [clj-http.lite.util]
-        [clojure.test]))
+(ns clj-http.test.cookies)
+
+;; (use '[clj-http.lite.util]
+;;      '[clojure.test])
 
 ;; (defn refer-private [ns]
 ;;   (doseq [[symbol var] (ns-interns ns)]

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -32,7 +32,7 @@
     [:delete "/delete-with-body"]
     {:status 200 :body "delete-with-body"}))
 
-(defn make-server ^Server []
+(defn make-server ^org.eclipse.jetty.server.Server []
   (ring/run-jetty handler {:port         0 ;; Use a free port
                            :join?        false
                            :ssl-port     0 ;; Use a free port
@@ -43,11 +43,11 @@
 (def ^:dynamic *server* nil)
 
 (defn current-port []
-  (let [^Server s *server*]
+  (let [^org.eclipse.jetty.server.Server s *server*]
     (->> s
          .getConnectors
          (filter (comp #{SelectChannelConnector} class))
-         ^SelectChannelConnector (first)
+         ^org.eclipse.jetty.server.nio.SelectChannelConnector (first)
          .getLocalPort)))
 
 (defn current-https-port []
@@ -55,7 +55,7 @@
     (->> s
          .getConnectors
          (filter (comp #{SslSelectChannelConnector} class))
-         ^SslSelectChannelConnector (first)
+         ^org.eclipse.jetty.server.nio.SslSelectChannelConnector (first)
          .getLocalPort)))
 
 (defn with-server [t]
@@ -153,10 +153,10 @@
 
 (deftest ^{:integration true} self-signed-ssl-get
   (let [client-opts {:request-method :get
-                     :uri "/get"
+                     :uri            "/get"
                      :scheme         :https
-                     :server-name (str "localhost:" (current-https-port))
-                     :port        (current-https-port)}]
+                     :server-name    (str "localhost:" (current-https-port))
+                     :port           (current-https-port)}]
     (is (thrown? javax.net.ssl.SSLException
                  (request client-opts)))
     (let [resp (request (assoc client-opts :insecure? true))]

--- a/test/clj_http/test/core.clj
+++ b/test/clj_http/test/core.clj
@@ -55,7 +55,7 @@
     (->> s
          .getConnectors
          (filter (comp #{SslSelectChannelConnector} class))
-         ^org.eclipse.jetty.server.nio.SslSelectChannelConnector (first)
+         ^org.eclipse.jetty.server.ssl.SslSelectChannelConnector (first)
          .getLocalPort)))
 
 (defn with-server [t]


### PR DESCRIPTION
* Make Slingshot `:provided`, offer a ns/API without it
  * The new ns uses the old ns implementation with zero changes, other than replacing `throw+` with `throw`+`ex-info`
  * The old ns is refactored to use the new ns's implementation, for DRYness, while keeping all metadata.
  * Fixes #10
* Setup Eastwood in CI
  * Seemed a good idea in face of the slightly dense details that support these changes.