### PR TITLE
ci: add windows to matrix, freshen config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,51 +3,147 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
-        clojure-version: ["1.8", "1.9", "1.10"]
-        java-version: ["8", "11", "16"]
+        os: ["ubuntu", "windows"]
+        clojure-version: ["1.8", "1.9", "1.10", "1.11"]
+        java-version: ["8", "11", "17"]
+
+    name: ${{ matrix.os }} clj-${{ matrix.clojure-version }} jdk${{ matrix.java-version }}
+
     steps:
-      - name: Prepare java
-        uses: actions/setup-java@v2
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Clojure deps cache
+        uses: actions/cache@v3
         with:
-          distribution: "adopt"
+          path: |
+            ~/.m2/repository
+            ~/.deps.clj
+            ~/.gitlibs
+          key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
           java-version: ${{ matrix.java-version }}
-      - name: Setup Clojure
-        uses: DeLaGuardo/setup-clojure@9.4
-        with:
-          cli: 'latest'
-      - name: Checkout
-        uses: actions/checkout@v2-beta
-      - name: Run tests
-        run: clojure -M:${{ matrix.clojure-version }}:test
-  bb-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2-beta
-      - name: Setup Babashka
+
+      - name: Setup Clojure Tooling
         uses: DeLaGuardo/setup-clojure@9.4
         with:
           bb: 'latest'
-      - name: tests
+          cli: 'latest'
+
+      - name: Tools versions
+        run: |
+          echo "bb --version"
+          bb --version
+          echo "clojure --version"
+          clojure --version
+          echo "java -version"
+          java -version
+
+      - name: Bring down deps
+        run: bb deps
+
+      - name: Run tests
+        run: clojure -M:${{ matrix.clojure-version }}:test
+
+  bb-test:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu", "windows"]
+
+    name: ${{ matrix.os }} bb
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Clojure deps cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.deps.clj
+            ~/.gitlibs
+          key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: '17'
+
+      - name: Setup Clojure Tooling
+        uses: DeLaGuardo/setup-clojure@9.4
+        with:
+          bb: 'latest'
+
+      - name: Tools versions
+        run: |
+          echo "bb --version"
+          bb --version
+          echo "java -version"
+          java -version
+
+      - name: Run tests
         run: bb test:bb
+
   deploy:
     runs-on: ubuntu-latest
     needs:
       - test
       - bb-test
+
     steps:
       - name: Checkout
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-        uses: actions/checkout@v2-beta
-      - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.5
+
+      - name: Clojure deps cache
+        uses: actions/cache@v3
         with:
-          # Install just one or all simultaneously
-          cli: 1.10.3.1029 # Clojure CLI based on tools.deps
+          path: |
+            ~/.m2/repository
+            ~/.deps.clj
+            ~/.gitlibs
+          key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Clojure Tooling
+        uses: DeLaGuardo/setup-clojure@9.4
+        with:
+          bb: 'latest'
+          cli: 'latest'
+
+      - name: Tools versions
+        run: |
+          echo "bb --version"
+          bb --version
+          echo "clojure --version"
+          clojure --version
+          echo "java -version"
+          java -version
+
+      - name: Bring down deps
+        run: bb deps
+
       - name: Deploy
         env:
           CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}


### PR DESCRIPTION
Add Windows to test matrix for jvm and bb tests
No longer failing fast on first matrix job failure
Bump GitHub actions
Employ deps cache
Switch to temurin for Java vendor
Report which tools versions were installed
Download deps prior to running main clj jvm action

Closes #21