### PR TITLE
tests: rename test namespaces to end in -test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,9 +19,7 @@
                 org.slf4j/jcl-over-slf4j {:mvn/version "1.7.36"}
                 org.slf4j/jul-to-slf4j {:mvn/version "1.7.36"}
                 org.slf4j/log4j-over-slf4j {:mvn/version "1.7.36"}}
-   :main-opts ["-m" "cognitect.test-runner"
-               ;; our test namespaces do not always end in -test, hence the override:
-               "--namespace-regex" "clj-http\\.test\\..*"]}
+   :main-opts ["-m" "cognitect.test-runner"]}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.08.03"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -1,6 +1,6 @@
-(ns clj-http.test.client
+(ns clj-http.test.client-test
   (:require [clj-http.lite.client :as client]
-            [clj-http.test.core :refer [base-req with-server current-port]]
+            [clj-http.test.core-test :refer [base-req with-server current-port]]
             [clj-http.lite.util :as util]
             [clojure.test :refer [deftest is testing use-fixtures]])
   (:import (java.net UnknownHostException)))

--- a/test/clj_http/test/cookies_test.clj
+++ b/test/clj_http/test/cookies_test.clj
@@ -1,4 +1,4 @@
-(ns clj-http.test.cookies
+(ns clj-http.test.cookies-test
   #_(:use [clj-http.lite.util]
           [clojure.test]))
 

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -1,4 +1,4 @@
-(ns clj-http.test.core
+(ns clj-http.test.core-test
   (:require [clj-http.lite.core :as core]
             [clj-http.lite.util :as util]
             [clojure.test :refer [deftest is use-fixtures]]


### PR DESCRIPTION
It is what most folks and tools expect these days.

Closes #35