### PR TITLE
docs: review and update docstrings

### DIFF
--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,3 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Changelog" {:file "CHANGELOG.md"}]]}

--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -7,9 +7,9 @@
 (set! *warn-on-reflection* true)
 
 (defn parse-headers
-  "Takes a URLConnection and returns a map of names to values.
+  "Returns a map of names to values for URLConnection `conn`.
 
-   If a name appears more than once (like `set-cookie`) then the value
+   If a header name appears more than once (like `set-cookie`) then the value
    will be a vector containing the values in the order they appeared
    in the headers."
   [conn]
@@ -26,8 +26,8 @@
                     (vec v))))))))
 
 (defn- coerce-body-entity
-  "Coerce the http-entity from an HttpResponse to either a byte-array, or a
-  stream that closes itself and the connection manager when closed."
+  "Return body response from HttpURLConnection `conn` coerced to either a byte-array,
+  or a stream."
   [{:keys [as]} conn]
   (let [ins (try
               (.getInputStream ^HttpURLConnection conn)
@@ -74,11 +74,8 @@
 (def-insecure)
 
 (defn request
-  "Executes the HTTP request corresponding to the given Ring request map and
-   returns the Ring response map corresponding to the resulting HTTP response.
-
-   Note that where Ring uses InputStreams for the request and response bodies,
-   the clj-http uses ByteArrays for the bodies."
+  "Executes the HTTP request corresponding to the given Ring `req` map and
+   returns the Ring response map corresponding to the resulting HTTP response."
   [{:keys [request-method scheme server-name server-port uri query-string
            headers content-type character-encoding body socket-timeout
            conn-timeout insecure? save-request? follow-redirects

--- a/src/clj_http/lite/links.clj
+++ b/src/clj_http/lite/links.clj
@@ -54,8 +54,10 @@
     response))
 
 (defn wrap-links
-  "Add a :links key to the response map that contains parsed Link headers. The
-  links will be represented as a map, with the 'rel' value being the key. The
+  "Returns request wrapper fn for `client` that adds
+  a `:links` key to the response map that contains parsed link headers.
+
+  The links are returned as a map, with the 'rel' value being the key. The
   URI is placed under the 'href' key, to mimic the HTML link element.
 
   e.g. Link: <http://example.com/page2.html>; rel=next; title=\"Page 2\"

--- a/src/clj_http/lite/util.clj
+++ b/src/clj_http/lite/util.clj
@@ -9,29 +9,29 @@
 (set! *warn-on-reflection* true)
 
 (defn utf8-bytes
-  "Returns the UTF-8 bytes corresponding to the given string."
+  "Returns the UTF-8 bytes for string `s`."
   [#^String s]
   (.getBytes s "UTF-8"))
 
 (defn utf8-string
-  "Returns the String corresponding to the UTF-8 decoding of the given bytes."
+  "Returns the string for UTF-8 decoding of bytes `b`."
   [#^"[B" b]
   (String. b "UTF-8"))
 
 (defn url-decode
-  "Returns the form-url-decoded version of the given string, using either a
-  specified encoding or UTF-8 by default."
+  "Returns the form-url-decoded version of `encoded` string, using either a
+  specified `encoding` or UTF-8 by default."
   [^String encoded & [encoding]]
   (let [^String encoding (or encoding "UTF-8")]
     (URLDecoder/decode encoded encoding)))
 
 (defn url-encode
-  "Returns an UTF-8 URL encoded version of the given string."
+  "Returns an UTF-8 URL encoded version of `unencoded` string."
   [^String unencoded]
   (URLEncoder/encode unencoded "UTF-8"))
 
 (defmacro base64-encode
-  "Encode an array of bytes into a base64 encoded string."
+  "Encode an array of `unencoded` bytes into a base64 encoded string."
   [unencoded]
   (if (try (import 'javax.xml.bind.DatatypeConverter)
            (catch Exception _))
@@ -41,7 +41,7 @@
       `(.encodeToString (java.util.Base64/getEncoder) ~unencoded))))
 
 (defn to-byte-array
-  "Returns a byte array for the InputStream provided."
+  "Returns a byte array for InputStream `is`."
   [is]
   (let [chunk-size 8192
         baos (ByteArrayOutputStream.)
@@ -54,7 +54,7 @@
 
 
 (defn gunzip
-  "Returns a gunzip'd version of the given byte array."
+  "Returns a gunzip'd version of byte array `b`."
   [b]
   (when b
     (if (instance? InputStream b)
@@ -62,7 +62,7 @@
       (to-byte-array (GZIPInputStream. (ByteArrayInputStream. b))))))
 
 (defn gzip
-  "Returns a gzip'd version of the given byte array."
+  "Returns a gzip'd version byte array `b`."
   [b]
   (when b
     (let [baos (ByteArrayOutputStream.)
@@ -72,13 +72,13 @@
       (.toByteArray baos))))
 
 (defn inflate
-  "Returns a zlib inflate'd version of the given byte array."
+  "Returns a zlib inflate'd version byte array `b`."
   [b]
   (when b
     (to-byte-array (InflaterInputStream. (ByteArrayInputStream. b)))))
 
 (defn deflate
-  "Returns a deflate'd version of the given byte array."
+  "Returns a deflate'd version byte array `b`."
   [b]
   (when b
     (to-byte-array (DeflaterInputStream. (ByteArrayInputStream. b)))))


### PR DESCRIPTION
This exercise helped me to understand the API more deeply, hopefully it
will help our users too.

The biggest challenge was documenting `clj-http.lite.client/request`.
Its previous docstring was way too vague for me to understand, as a
user, what is available.

Also challenging is the lack of definition of the supported API.
I'm guessing our documented API is currently including lots of
unnecessary internals.

I reviewed all existing docstrings and updated where I thought I could
be clearer and/or more consistent. I added no new docstrings.

Also: added cljdoc.edn to explicitly list our docs.

Closes #36