### PR TITLE
Flatten nested query and form parameter maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 - If specified, request's body encoding is now applied, else defaults to UTF-8 ([#18](https://github.com/clj-commons/clj-http-lite/issues/18)) ([@lread](https://github.com/lread))
 - User info from request URL now applied to basic auth ([#34](https://github.com/clj-commons/clj-http-lite/issues/34)) ([@lread](https://github.com/lread))
+- Nested query and form parameters are now automatically flattened ([#43](https://github.com/clj-commons/clj-http-lite/issues/43)) ([@lread](https://github.com/lread))
 - Quality
+  - Docstrings reviewed and updated
   - Automated CI testing added for Windows ([#21](https://github.com/clj-commons/clj-http-lite/issues/21)) ([@lread](https://github.com/lread))
 
 ### 0.4.384

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -299,6 +299,23 @@
       (is (= "untouched" (:body resp)))
       (is (not (contains? resp :content-type))))))
 
+(deftest apply-on-nest-params
+  (let [param-client (client/wrap-nested-params identity)
+        params {:a
+                {:b
+                 {:c 5}
+                 :e
+                 {:f 6}}
+                :g 7}
+        resp (param-client {:form-params params :query-params params})]
+    (is (= {"a[b][c]" 5 "a[e][f]" 6 :g 7} (:form-params resp) (:query-params resp)))))
+
+(deftest pass-on-no-nest-params
+  (let [m-client (client/wrap-nested-params identity)
+        echo (m-client {:key :val})]
+    (is (= :val (:key echo)))
+    (is (not (:request-method echo)))))
+
 (deftest t-ignore-unknown-host
   (is (thrown? UnknownHostException (client/get "http://aorecuf892983a.com")))
   (is (nil? (client/get "http://aorecuf892983a.com"

--- a/test/clj_http/test/client_test.clj
+++ b/test/clj_http/test/client_test.clj
@@ -312,9 +312,9 @@
 
 (deftest pass-on-no-nest-params
   (let [m-client (client/wrap-nested-params identity)
-        echo (m-client {:key :val})]
-    (is (= :val (:key echo)))
-    (is (not (:request-method echo)))))
+        in {:key :val}
+        out (m-client in)]
+    (is (= out in))))
 
 (deftest t-ignore-unknown-host
   (is (thrown? UnknownHostException (client/get "http://aorecuf892983a.com")))


### PR DESCRIPTION
Brought over flattening code from clj-http but not the options to
enable/disable flattening.

For us, for now, it is always enabled.

See updates to README for examples.

Closes #43