### PR TITLE
Apply :insecure? ssl opt only to current request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 - If specified, request's body encoding is now applied, else defaults to UTF-8 ([#18](https://github.com/clj-commons/clj-http-lite/issues/18)) ([@lread](https://github.com/lread))
 - User info from request URL now applied to basic auth ([#34](https://github.com/clj-commons/clj-http-lite/issues/34)) ([@lread](https://github.com/lread))
 - Nested query and form parameters are now automatically flattened ([#43](https://github.com/clj-commons/clj-http-lite/issues/43)) ([@lread](https://github.com/lread))
+- The `:insecure?` option is now applied only to the current request ([#45](https://github.com/clj-commons/clj-http-lite/issues/45)) ([@lread](https://github.com/lread))
 - Quality
-  - Docstrings reviewed and updated
+  - Docstrings and README reviewed and updated
   - Automated CI testing added for Windows ([#21](https://github.com/clj-commons/clj-http-lite/issues/21)) ([@lread](https://github.com/lread))
 
 ### 0.4.384

--- a/bb/clj_http/lite/client_test.clj
+++ b/bb/clj_http/lite/client_test.clj
@@ -29,3 +29,10 @@
        (is false "should not reach here")
        (catch Exception e
          (is (:headers (ex-data e))))))
+
+(deftest insecure-test
+  (is (thrown? Exception
+               (client/get "https://expired.badssl.com")))
+  (is (= 200 (:status (client/get "https://expired.badssl.com" {:insecure? true}))))
+  (is (thrown? Exception
+               (client/get "https://expired.badssl.com"))))

--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -66,12 +66,16 @@
                                                     (checkServerTrusted [this certs authType]))])
                     (new java.security.SecureRandom))))))
 
+       ;; work-around for potential bug in bb/sci, type hints on lets might not
+       ;; always work as expected so factor out to fn with type hint on arg
+       (defn- trust-all-ssl!! [^HttpsURLConnection conn]
+         (.setHostnameVerifier conn @trust-all-hostname-verifier)
+         (.setSSLSocketFactory conn @trust-all-ssl-socket-factory))
+
        (defn- trust-all-ssl!
          [conn]
          (when (instance? HttpsURLConnection conn)
-           (let [^HttpsURLConnection conn conn]
-             (.setHostnameVerifier conn @trust-all-hostname-verifier)
-             (.setSSLSocketFactory conn @trust-all-ssl-socket-factory)))))))
+           (trust-all-ssl!! conn))))))
 
 (def-insecure)
 

--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -66,16 +66,12 @@
                                                     (checkServerTrusted [this certs authType]))])
                     (new java.security.SecureRandom))))))
 
-       ;; work-around for potential bug in bb/sci, type hints on lets might not
-       ;; always work as expected so factor out to fn with type hint on arg
-       (defn- trust-all-ssl!! [^HttpsURLConnection conn]
-         (.setHostnameVerifier conn @trust-all-hostname-verifier)
-         (.setSSLSocketFactory conn @trust-all-ssl-socket-factory))
-
        (defn- trust-all-ssl!
          [conn]
          (when (instance? HttpsURLConnection conn)
-           (trust-all-ssl!! conn))))))
+           (let [^HttpsURLConnection ssl-conn conn]
+             (.setHostnameVerifier ssl-conn @trust-all-hostname-verifier)
+             (.setSSLSocketFactory ssl-conn @trust-all-ssl-socket-factory)))))))
 
 (def-insecure)
 

--- a/test/clj_http/test/core_test.clj
+++ b/test/clj_http/test/core_test.clj
@@ -172,7 +172,10 @@
                  (request client-opts)))
     (let [resp (request (assoc client-opts :insecure? true))]
       (is (= 200 (:status resp)))
-      (is (= "get" (slurp-body resp))))))
+      (is (= "get" (slurp-body resp))))
+    (is (thrown? javax.net.ssl.SSLException
+                 (request client-opts))
+        "subsequent bad cert fetch throws")))
 
 (deftest ^{:integration true} t-save-request-obj
   (let [resp (request {:request-method :post :uri "/post"


### PR DESCRIPTION
Was formerly also being applied to all subsequent requests.

This change does break insecure? for current babashka (v0.9.161) which
does not currently allow setHostnameVerifier and setSSLSocketFactory to be called
on a HttpsURLConnection.

Closes #45