### PR TITLE
docs: split out README to guides [skip ci]

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,4 @@
 = `clj-http-lite`
-:toclevels: 4
-:toc: macro
-:lib-version: 0.4.392
 :project-src-coords: clj-commons/clj-http-lite
 :project-mvn-coords: org.clj-commons/clj-http-lite
 :url-doc: https://cljdoc.org/d/{project-mvn-coords}
@@ -19,392 +16,55 @@ ____
 This is a clj-commons maintained fork of the archived https://github.com/hiredman/clj-http-lite[`hiredman/clj-http-lite`] repo.
 ____
 
-toc::[]
+== Documentation
 
-== Installation
+* link:doc/01-user-guide.adoc[User Guide]
+* link:doc/02-developer-guide.adoc[Developer Guide]
 
-Clojure cli users, add the following under `:deps` in your `deps.edn` file. +
-Babashka users, add the following under `:deps` in your `bb.edn` file:
-[source,clojure,subs="attributes+"]
-----
-    org.clj-commons/clj-http-lite {:mnv/version "{lib-version}"}
-----
+== Used In...
+Some project using clj-http-lite are:
 
-Lein users, add the following into the `:dependencies` vector in your `project.clj` file:
+* https://github.com/clj-holmes/clj-holmes[clj-holmes] - Static application security tool for finding vulnerable Clojure code
+* https://cljdoc.org/[cljdoc site] (https://github.com/cljdoc/cljdoc[sources]) - A central documentation hub for the Clojure community
+* https://github.com/clj-commons/etaoin[Etaoin] - Pure Clojure WebDriver protocol implementation
+* https://github.com/djblue/portal[portal] (for tests)  - A clojure tool to navigate through your data
+* https://github.com/sethtrain/raven-clj[raven-clj] - A Clojure interface to Sentry
+* https://github.com/epiccastle/spire[spire] - pragmatic provisioning using Clojure
 
-[source,clojure,subs="attributes+"]
-----
-    [org.clj-commons/clj-http-lite "{lib-version}"]
-----
+Don't see your project listed? Let us know, we'll be happy to include it!
 
-== Differences from clj-http
+== People
 
-* Instead of Apache HttpClient, clj-http-lite uses HttpURLConnection
-* No automatic JSON decoding for response bodies
-* No automatic request body encoding beyond charset and url encoding of form params
-* No cookie support
-* No multipart form uploads
-* No persistent connection support
-* Fewer options
-* namespace rename `clj-http.*` -> `clj-http.lite.*`
+=== Contributors
 
-Like its namesake, clj-http-lite is light and simple, but ping us if there is some clj-http feature you’d like to see in clj-http-lite.
-We can discuss.
+A big thank you to al the people who have contributed directly to clj-http-lite!
 
-== History
+* https://github.com/katox[@katox]
+* https://github.com/sattvik[@sattvik]
+* https://github.com/AdamClements[@AdamClements]
+* https://github.com/ivarref[@ivarref]
+* https://github.com/imrekoszo[@imrekoszo]
+* https://github.com/avichalp[@avichalp] 
+* https://github.com/arnaudbos[@arnaudbos]
+* https://github.com/gaberger[@gaberger]
+* https://github.com/vemv[@vemv]
+* https://github.com/deas[@deas]
+* https://github.com/anderseknert[@anderseknert]
 
-* Sep 2011 - https://github.com/dakrone/clj-http[dakrone/clj-http] created (and is still actively maintained)
-* Feb 2012 - https://github.com/hiredman/clj-http-lite[hiredman/clj-http-lite] (now archived) forked from `dakrone/clj-http` to use Java’s HttpURLConnection instead of Apache HttpClient.
-* Jul 2018 - `martinklepsch/clj-http-lite` forked from `hiredman/clj-http-lite` for new development and maintenance
-* Nov 2021 - Martin transfered his fork to `clj-commons/clj-http-lite` so it could get the ongoing love it needs from the Clojure community
+Don't see your name? Our apologies! Let us know and we'll add you in.
 
-== Usage
+=== Founders
 
-=== General
-HTTP client functionality is provided by the `clj-http.lite.client` namespace:
+* https://github.com/dakrone[@dakrone] - the creator of clj-http
+* https://github.com/hiredman[@hiredman] - the creator of clj-http-lite
+* https://github.com/martinklepsch[@martinklepsch] - maintainer of clj-http-lite
 
-[source,clojure]
-----
-(require '[clj-http.lite.client :as client])
-----
+=== Current Active Maintainers
 
-The client supports simple `get`, `head`, `put`, `post`, and `delete` requests.
-They all return Ring-style response maps:
-
-[source,clojure]
-----
-(client/get "https://google.com")
-=> {:status 200
-    :headers {"date" "Wed, 17 Aug 2022 21:37:58 GMT"
-              "cache-control" "private, max-age=0"
-              "content-type" "text/html; charset=ISO-8859-1"
-              ...}
-    :body "<!doctype html>..."}
-----
-
-TIP: We encourage you to try out these examples in your REPL, `httpbin.org` is a free HTTP test playground and used in many of our examples.
-
-[source,clojure]
-----
-(client/get "https://httpbin.org/user-agent")
-
-;; Tell the server you'd like a json response
-(client/get "https://httpbin.org/user-agent" {:accept :json})
-
-;; Or maybe you'd like html back
-(client/get "https://httpbin.org/html" {:accept "text/html"})
-
-;; Various options
-(client/post "https://httpbin.org/anything"
-  {:basic-auth ["joe" "cool"]
-   :body "{\"json\": \"input\"}"
-   :headers {"X-Api-Version" "2"}
-   :content-type :json
-   :socket-timeout 1000
-   :conn-timeout 1000
-   :accept :json})
-
-;; Need to contact a server with an untrusted SSL cert?
-(client/get "https://expired.badssl.com" {:insecure? true})
-
-;; By default we automatically follow 30* redirects...
-(client/get "https://httpbin.org/redirect-to?url=https%3A%2F%2Fclojure.org")
-
-;; ... but you don't have to
-(client/get "https://httpbin.org/redirect-to?url=https%3A%2F%2Fclojure.org"
-            {:follow-redirects false})
-
-;; Send form params as a urlencoded body
-(client/post "https://httpbin.org/post" {:form-params {:foo "bar"}})
-
-;; Basic authentication
-(client/get "https://joe:cool@httpbin.org/basic-auth/joe/cool")
-(client/get "https://httpbin.org/basic-auth/joe/cool" {:basic-auth ["joe" "cool"]})
-(client/get "https://httpbin.org/basic-auth/joe/cool" {:basic-auth "joe:cool"})
-
-;; Query parameters can be specified as a map
-(client/get "https://httpbin.org/get" {:query-params {"q" "foo, bar"}})
-----
-
-The client transparently accepts and decompresses the `gzip` and `deflate` content encodings.
-
-[source,clojure]
-----
-(client/get "https://httpbin.org/gzip")
-
-(client/get "https://httpbin.org/deflate")
-----
-
-=== Nested params
-
-Nested parameter `{:a {:b 1}}` in `:form-params` or `:query-params` is automatically flattened to `a[b]=1`.
-
-[source,clojure]
-----
-(-> (client/get "https://httpbin.org/get"
-                {:query-params {:one {:two 2 :three 3}}})
-    :body
-    println)
-{
-  "args": {
-    "one[three]": "3",
-    "one[two]": "2"
-  },
-  ...
-}
-
-(-> (client/post "https://httpbin.org/post"
-                 {:form-params {:one {:two 2
-                                      :three {:four {:five 5}}}
-                                :six 6}})
-    :body
-    println)
-{
-  ...
-  "form": {
-    "one[three][four][five]": "5",
-    "one[two]": "2",
-    "six": "6"
-  },
-  ...
-}
-----
-
-=== Request body coercion
-
-[source,clojure]
-----
-;; body as byte-array
-(client/post "https://httbin.org/post" {:body (.getBytes "testing123")})
-
-;; body from a string
-(client/post "https://httpbin.org/post" {:body "testing456"})
-
-;; string :body-encoding is optional and defaults to "UTF-8"
-(client/post "https://httpbin.org/post"
-             {:body "mystring" :body-encoding "UTF-8"})
-
-;; body from a file
-(require '[clojure.java.io :as io])
-(spit "clj-http-lite-test.txt" "from a file")
-(client/post "https://httpbin.org/post"
-             {:body (io/file "clj-http-lite-test.txt")
-              :body-encoding "UTF-8"})
-
-;; from a stream
-(with-open [is (io/input-stream "clj-http-lite-test.txt")]
-  (client/post "https://httpbin.org/post"
-               {:body (io/input-stream "clj-http-lite-test.txt")})  )
-----
-
-=== Output body coercion
-
-[source,clojure]
-----
-;; The default response body is a string body
-(client/get "https://clojure.org")
-
-;; Coerce to a byte-array
-(client/get "http://clojure.org" {:as :byte-array})
-
-;; Coerce to a string with using a specific charset, default is UTF-8
-(client/get "http://clojure.org" {:as "US-ASCII"})
-
-;; Try to automatically coerce the body based on the content-type
-;; response header charset
-(client/get "https://google.com" {:as :auto})
-
-;; Return the body as a stream
-;; Note that the connection to the server will NOT be closed until the
-;; stream has been read
-(let [res (client/get "https://clojure.org" {:as :stream})]
-  (with-open [body-stream (:body res)]
-    (slurp body-stream)))
-----
-
-A more general `request` function is also available, which is useful as a primitive for building higher-level interfaces:
-
-[source,clojure]
-----
-(defn api-action [method path & [opts]]
-  (client/request
-    (merge {:method method :url (str "https://some.api/" path)} opts)))
-----
-
-=== Exceptions
-
-When a server returns an exceptional HTTP status code, by default, clj-http-lite throws an `ex-info` exception.
-The response is included as `ex-data`.
-
-[source,clojure]
-----
-(client/get "https://httpbin.org/404")
-;; => ExceptionInfo clj-http: status 404  clojure.core/ex-info (core.clj:4617)
-
-(-> *e ex-data :status)
-;; => 404
-
-(-> *e ex-data keys)
-;; => (:headers :status :body)
-----
-
-You can suppress HTTP status exceptions and handle them yourself via the `:throw-exceptions` option:
-
-[source,clojure]
-----
-(client/get "https://httpbin.org/404" {:throw-exceptions false})
-----
-
-You can choose to ignore an unknown host via `:ingore-unknown-host?` option.
-When enabled, requests return `nil` if the host is not found.
-
-[source,clojure]
-----
-(client/get "http://aoeuntahuf89o.com" {:ignore-unknown-host? true})
-;; => nil
-----
-
-=== Proxies
-
-A proxy can be specified by setting the Java properties: `<scheme>.proxyHost` and `<scheme>.proxyPort` where `<scheme>` is the client scheme used (normally `http' or `https').
-
-== Mocking clj-http-lite responses
-
-Mocking responses from the clj-http-lite client in tests is easily accomplished with e.g. `with-redefs`:
-
-[source,clojure]
-----
-(defn my-http-function []
-  (let [response (client/get "https://example.org")]
-    (when (= 200 (:status response))
-      (:body response))))
-
-(deftest my-http-function-test
-  (with-redefs [client/get (fn [_] {:status 200 :headers {"content-type" "text/plain"} :body "OK"})]
-    (is (= (my-http-function) "OK"))))
-----
-
-More advanced mocking may be performed by matching attributes in the `request`, like the `mock-response` function below.
-
-[source,clojure]
-----
-(ns http-test
-  (:require [clojure.data.json :as json]
-            [clojure.test :refer [deftest is testing]]
-            [clj-http.lite.client :as client]))
-
-(defn send-report [data]
-  (:body (client/post "https://example.com/reports" {:body data})))
-
-(defn get-users []
-  (json/read-str (:body (client/get "https://example.com/users"))))
-
-(defn get-admin []
-  (let [response (client/get "https://example.com/admin")]
-    (if (= 200 (:status response))
-      (:body response)
-      "403 Forbidden")))
-
-(defn mock-response [{:keys [url method body] :as request}]
-  (condp = [url method]
-    ["https://example.com/reports" :post]
-    {:status  201 :headers {"content-type" "text/plain"} :body (str "created: " body)}
-
-    ["https://example.com/users" :get]
-    {:status 200 :headers {"content-type" "application/json"} :body (json/write-str ["joe" "jane" "bob"])}
-
-    ["https://example.com/admin" :get]
-    {:status 403 :headers {"content-type" "text/plain"} :body "forbidden"}
-
-    (throw (ex-info "unexpected request" request))))
-
-(deftest send-report-test
-  (with-redefs [client/request mock-response]
-    (testing "sending report"
-      (is (= (send-report {:balance 100}) "created: {:balance 100}")))
-    (testing "list users"
-      (is (= (get-users) ["joe" "jane" "bob"])))
-    (testing "access admin page"
-      (is (= (get-admin) "403 Forbidden")))))
-----
-
-== GraalVM Native Image Tips
-
-You’ll need to enable url protocols when building your native image.
-
-See https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/URLProtocols/[GraalVM docs].
-
-== Design
-
-The design of `clj-http` (and therefore `clj-http-lite`) is inspired by the https://github.com/ring-clojure/ring[Ring] protocol for Clojure HTTP server applications.
-
-The client in `clj-http.lite.core` makes HTTP requests according to a given Ring request map and returns Ring response maps corresponding to the resulting HTTP response.
-The function `clj-http.lite.client/request` uses Ring-style middleware to layer functionality over the core HTTP request/response implementation.
-Methods like `clj-http.lite.client/get` are sugar over this `clj-http.lite.client/request` function.
-
-== Development
-
-=== Clojure JVM Tests
-
-Optionally:
-
-[source,shell]
-----
-$ bb clean
-$ bb deps
-----
-
-Run all Clojure tests against minimum supported version of Clojure (1.8):
-
-[source,shell]
-----
-$ bb test:jvm
-----
-
-Run tests against a specific Clojure version, for example 1.11
-
-[source,shell]
-----
-$ bb test:jvm --clj-version 1.11
-----
-
-You can also include cognitect test runner options:
-
-[source,shell]
-----
-$ bb test:jvm --clj-version 1.9 --namespace-regex '*.sanity.*'
-----
-
-=== Babashka Tests
-
-To run the entire test suite under Babashka:
-
-[source,shell]
-----
-$ bb test:bb
-----
-
-You can also include cognitect test runner options:
-
-[source,shell]
-----
-$ bb test:bb --var clj-http.lite.integration-test/roundtrip
-----
-
-=== Linting
-
-Our CI workflow lints sources with clj-kondo, and you can too!
-
-[source,shell]
-----
-$ bb lint
-----
-
-=== Release
-
-To release a new version, run `bb publish` which will push a new tag.
-CI will take care of the rest.
+* https://github.com/lread[@lread]
+* https://github.com/borkdude[@borkdude]
 
 == License
+We respect the original license at time of forking from clj-http:
 
 Released under the MIT License: http://www.opensource.org/licenses/mit-license.php

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -28,6 +28,7 @@
   (let [;; commit count + 1 for README update
         cc (inc (shared/git-count-revs))
         tag (str "Release-" (shared/version cc))]
+    ;; TODO: Update
     (replace-version "README.md" shared/base-version cc)
     (replace-version "project.clj" shared/base-version cc)
     (shell "git add README.md project.clj")

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -1,0 +1,350 @@
+= User Guide
+:toclevels: 5
+:toc:
+:lib-version: 0.4.392
+
+== Introduction
+Clj-http-lite is a Clojure, Babashka and GraalVM compatible liteweight subset of http://github.com/dakrone/clj-http[clj-http].
+
+=== Differences from clj-http
+
+* Instead of Apache HttpClient, clj-http-lite uses HttpURLConnection
+* No automatic JSON decoding for response bodies
+* No automatic request body encoding beyond charset and url encoding of form params
+* No cookie support
+* No multipart form uploads
+* No persistent connection support
+* Fewer options
+* namespace rename `clj-http.*` -> `clj-http.lite.*`
+
+Like its namesake, clj-http-lite is light and simple, but ping us if there is some clj-http feature you’d like to see in clj-http-lite.
+We can discuss.
+
+=== Supported Environments [[supported-envs]]
+
+* JDK 8, 11, 17
+* Clojure 1.8 runtime and above
+* Babashka current release
+* Windows, Linux, macOS
+
+=== History
+
+* Sep 2011 - https://github.com/dakrone/clj-http[dakrone/clj-http] created (and is still actively maintained)
+* Feb 2012 - https://github.com/hiredman/clj-http-lite[hiredman/clj-http-lite] (now archived) forked from `dakrone/clj-http` to use Java’s HttpURLConnection instead of Apache HttpClient.
+* Jul 2018 - `martinklepsch/clj-http-lite` forked from `hiredman/clj-http-lite` for new development and maintenance
+* Nov 2021 - Martin transfered his fork to `clj-commons/clj-http-lite` so it could get the ongoing love it needs from the Clojure community
+
+=== Interesting Alternatives
+
+Maybe clj-http-lite is not your cup of tea? Some alternatives to explore:
+
+Clojure based:
+
+* http://github.com/dakrone/clj-http[clj-http] - heavier than clj-http-lite, but has many more features
+
+Babashka compatible:
+
+* https://github.com/schmee/java-http-clj[java-http-clj] - Clojure wrapper for java.net.http with async, HTTP/2 and WebSockets
+* https://github.com/http-kit/http-kit[http-kit] - minimalist, event-driven, high-performance Clojure HTTP server/client library with WebSocket and asynchronous support
+* https://github.com/gnarroway/hato[hato] - An HTTP client for Clojure, wrapping JDK 11's HttpClient
+* https://github.com/babashka/babashka.curl[babashka.curl] - A tiny curl wrapper via idiomatic Clojure, inspired by clj-http, Ring and friends
+
+== Installation
+
+Clojure cli users, add the following under `:deps` in your `deps.edn` file. +
+Babashka users, add the following under `:deps` in your `bb.edn` file:
+[source,clojure,subs="attributes+"]
+----
+    org.clj-commons/clj-http-lite {:mnv/version "{lib-version}"}
+----
+
+Lein users, add the following into the `:dependencies` vector in your `project.clj` file:
+
+[source,clojure,subs="attributes+"]
+----
+    [org.clj-commons/clj-http-lite "{lib-version}"]
+----
+
+== Usage
+
+=== General
+HTTP client functionality is provided by the `clj-http.lite.client` namespace:
+
+[source,clojure]
+----
+(require '[clj-http.lite.client :as client])
+----
+
+The client supports simple `get`, `head`, `put`, `post`, and `delete` requests.
+They all return Ring-style response maps:
+
+[source,clojure]
+----
+(client/get "https://google.com")
+=> {:status 200
+    :headers {"date" "Wed, 17 Aug 2022 21:37:58 GMT"
+              "cache-control" "private, max-age=0"
+              "content-type" "text/html; charset=ISO-8859-1"
+              ...}
+    :body "<!doctype html>..."}
+----
+
+TIP: We encourage you to try out these examples in your REPL, `httpbin.org` is a free HTTP test playground and used in many of our examples.
+
+[source,clojure]
+----
+(client/get "https://httpbin.org/user-agent")
+
+;; Tell the server you'd like a json response
+(client/get "https://httpbin.org/user-agent" {:accept :json})
+
+;; Or maybe you'd like html back
+(client/get "https://httpbin.org/html" {:accept "text/html"})
+
+;; Various options
+(client/post "https://httpbin.org/anything"
+  {:basic-auth ["joe" "cool"]
+   :body "{\"json\": \"input\"}"
+   :headers {"X-Api-Version" "2"}
+   :content-type :json
+   :socket-timeout 1000
+   :conn-timeout 1000
+   :accept :json})
+
+;; Need to contact a server with an untrusted SSL cert?
+(client/get "https://expired.badssl.com" {:insecure? true})
+
+;; By default we automatically follow 30* redirects...
+(client/get "https://httpbin.org/redirect-to?url=https%3A%2F%2Fclojure.org")
+
+;; ... but you don't have to
+(client/get "https://httpbin.org/redirect-to?url=https%3A%2F%2Fclojure.org"
+            {:follow-redirects false})
+
+;; Send form params as a urlencoded body
+(client/post "https://httpbin.org/post" {:form-params {:foo "bar"}})
+
+;; Basic authentication
+(client/get "https://joe:cool@httpbin.org/basic-auth/joe/cool")
+(client/get "https://httpbin.org/basic-auth/joe/cool" {:basic-auth ["joe" "cool"]})
+(client/get "https://httpbin.org/basic-auth/joe/cool" {:basic-auth "joe:cool"})
+
+;; Query parameters can be specified as a map
+(client/get "https://httpbin.org/get" {:query-params {"q" "foo, bar"}})
+----
+
+The client transparently accepts and decompresses the `gzip` and `deflate` content encodings.
+
+[source,clojure]
+----
+(client/get "https://httpbin.org/gzip")
+
+(client/get "https://httpbin.org/deflate")
+----
+
+=== Nested params
+
+Nested parameter `{:a {:b 1}}` in `:form-params` or `:query-params` is automatically flattened to `a[b]=1`.
+
+[source,clojure]
+----
+(-> (client/get "https://httpbin.org/get"
+                {:query-params {:one {:two 2 :three 3}}})
+    :body
+    println)
+{
+  "args": {
+    "one[three]": "3",
+    "one[two]": "2"
+  },
+  ...
+}
+
+(-> (client/post "https://httpbin.org/post"
+                 {:form-params {:one {:two 2
+                                      :three {:four {:five 5}}}
+                                :six 6}})
+    :body
+    println)
+{
+  ...
+  "form": {
+    "one[three][four][five]": "5",
+    "one[two]": "2",
+    "six": "6"
+  },
+  ...
+}
+----
+
+=== Request body coercion
+
+[source,clojure]
+----
+;; body as byte-array
+(client/post "https://httbin.org/post" {:body (.getBytes "testing123")})
+
+;; body from a string
+(client/post "https://httpbin.org/post" {:body "testing456"})
+
+;; string :body-encoding is optional and defaults to "UTF-8"
+(client/post "https://httpbin.org/post"
+             {:body "mystring" :body-encoding "UTF-8"})
+
+;; body from a file
+(require '[clojure.java.io :as io])
+(spit "clj-http-lite-test.txt" "from a file")
+(client/post "https://httpbin.org/post"
+             {:body (io/file "clj-http-lite-test.txt")
+              :body-encoding "UTF-8"})
+
+;; from a stream
+(with-open [is (io/input-stream "clj-http-lite-test.txt")]
+  (client/post "https://httpbin.org/post"
+               {:body (io/input-stream "clj-http-lite-test.txt")})  )
+----
+
+=== Output body coercion
+
+[source,clojure]
+----
+;; The default response body is a string body
+(client/get "https://clojure.org")
+
+;; Coerce to a byte-array
+(client/get "http://clojure.org" {:as :byte-array})
+
+;; Coerce to a string with using a specific charset, default is UTF-8
+(client/get "http://clojure.org" {:as "US-ASCII"})
+
+;; Try to automatically coerce the body based on the content-type
+;; response header charset
+(client/get "https://google.com" {:as :auto})
+
+;; Return the body as a stream
+;; Note that the connection to the server will NOT be closed until the
+;; stream has been read
+(let [res (client/get "https://clojure.org" {:as :stream})]
+  (with-open [body-stream (:body res)]
+    (slurp body-stream)))
+----
+
+A more general `request` function is also available, which is useful as a primitive for building higher-level interfaces:
+
+[source,clojure]
+----
+(defn api-action [method path & [opts]]
+  (client/request
+    (merge {:method method :url (str "https://some.api/" path)} opts)))
+----
+
+=== Exceptions
+
+When a server returns an exceptional HTTP status code, by default, clj-http-lite throws an `ex-info` exception.
+The response is included as `ex-data`.
+
+[source,clojure]
+----
+(client/get "https://httpbin.org/404")
+;; => ExceptionInfo clj-http: status 404  clojure.core/ex-info (core.clj:4617)
+
+(-> *e ex-data :status)
+;; => 404
+
+(-> *e ex-data keys)
+;; => (:headers :status :body)
+----
+
+You can suppress HTTP status exceptions and handle them yourself via the `:throw-exceptions` option:
+
+[source,clojure]
+----
+(client/get "https://httpbin.org/404" {:throw-exceptions false})
+----
+
+You can choose to ignore an unknown host via `:ingore-unknown-host?` option.
+When enabled, requests return `nil` if the host is not found.
+
+[source,clojure]
+----
+(client/get "http://aoeuntahuf89o.com" {:ignore-unknown-host? true})
+;; => nil
+----
+
+=== Proxies
+
+A proxy can be specified by setting the Java properties: `<scheme>.proxyHost` and `<scheme>.proxyPort` where `<scheme>` is the client scheme used (normally `http' or `https').
+
+== Mocking clj-http-lite responses
+
+Mocking responses from the clj-http-lite client in tests is easily accomplished with e.g. `with-redefs`:
+
+[source,clojure]
+----
+(defn my-http-function []
+  (let [response (client/get "https://example.org")]
+    (when (= 200 (:status response))
+      (:body response))))
+
+(deftest my-http-function-test
+  (with-redefs [client/get (fn [_] {:status 200 :headers {"content-type" "text/plain"} :body "OK"})]
+    (is (= (my-http-function) "OK"))))
+----
+
+More advanced mocking may be performed by matching attributes in the `request`, like the `mock-response` function below.
+
+[source,clojure]
+----
+(ns http-test
+  (:require [clojure.data.json :as json]
+            [clojure.test :refer [deftest is testing]]
+            [clj-http.lite.client :as client]))
+
+(defn send-report [data]
+  (:body (client/post "https://example.com/reports" {:body data})))
+
+(defn get-users []
+  (json/read-str (:body (client/get "https://example.com/users"))))
+
+(defn get-admin []
+  (let [response (client/get "https://example.com/admin")]
+    (if (= 200 (:status response))
+      (:body response)
+      "403 Forbidden")))
+
+(defn mock-response [{:keys [url method body] :as request}]
+  (condp = [url method]
+    ["https://example.com/reports" :post]
+    {:status  201 :headers {"content-type" "text/plain"} :body (str "created: " body)}
+
+    ["https://example.com/users" :get]
+    {:status 200 :headers {"content-type" "application/json"} :body (json/write-str ["joe" "jane" "bob"])}
+
+    ["https://example.com/admin" :get]
+    {:status 403 :headers {"content-type" "text/plain"} :body "forbidden"}
+
+    (throw (ex-info "unexpected request" request))))
+
+(deftest send-report-test
+  (with-redefs [client/request mock-response]
+    (testing "sending report"
+      (is (= (send-report {:balance 100}) "created: {:balance 100}")))
+    (testing "list users"
+      (is (= (get-users) ["joe" "jane" "bob"])))
+    (testing "access admin page"
+      (is (= (get-admin) "403 Forbidden")))))
+----
+
+== GraalVM Native Image Tips
+
+You’ll need to enable url protocols when building your native image.
+
+See https://www.graalvm.org/22.2/reference-manual/native-image/dynamic-features/URLProtocols/[GraalVM docs].
+
+== Design
+
+The design of `clj-http` (and therefore `clj-http-lite`) is inspired by the https://github.com/ring-clojure/ring[Ring] protocol for Clojure HTTP server applications.
+
+The client in `clj-http.lite.core` makes HTTP requests according to a given Ring request map and returns Ring response maps corresponding to the resulting HTTP response.
+The function `clj-http.lite.client/request` uses Ring-style middleware to layer functionality over the core HTTP request/response implementation.
+Methods like `clj-http.lite.client/get` are sugar over this `clj-http.lite.client/request` function.

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -1,0 +1,106 @@
+= Developer Guide
+
+== Contributing
+
+We very much appreciate contributions from the community.
+
+=== Issue First Please
+
+If you have an idea or a fix, please do raise a GitHub issue before investing in any coding effort. That way we can discuss first.
+Writing code is the easy part, maintaining it forever is the hard part.
+
+That said, if you notice a simple typo, a PR without an issue is fine.
+
+=== Submitting a Pull Request
+
+Please never force push on your PR, as this makes reviewing incremental changes impossible for us.
+When we merge your PR, we'll usually squash it, so that will clean up any rambling work in progress.
+
+== Environmental Overview
+
+=== Developer Prerequisites
+
+The current version of Babashka.
+
+* Our scripts use Babashka to launch Clojure, so you don't absolutely need the Clojure cli's `clojure` command.
+* JDK, see <<01-user-guide.adoc#supported-envs,supported environments>>
+
+=== Babashka Compatibility
+
+Clj-http-lite is babashka compatible.
+
+Babashka supports everything that clj-http-lite needs, but when making changes, be aware that your code must also work under Babashka.
+
+If your change requires something Babashka does not currently support, we can bring it up with the babashka team, things like adding a class are usually approved.
+
+== Docs
+
+All documentation is written in AsciiDoc.
+@lread likes to follow https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line[AsciiDoc best practice of one sentence per line] but won't be entirely pedantic about that.
+
+We host our docs on cljdoc.
+
+== Babashka Tasks
+
+We use Babashka tasks, to see all available tasks run:
+
+[source,shell]
+----
+bb tasks
+----
+
+=== Clojure JVM Tests
+
+Optionally:
+
+[source,shell]
+----
+$ bb clean
+$ bb deps
+----
+
+Run all Clojure tests against minimum supported version of Clojure (1.8):
+
+[source,shell]
+----
+$ bb test:jvm
+----
+
+Run tests against a specific Clojure version, for example 1.11
+
+[source,shell]
+----
+$ bb test:jvm --clj-version 1.11
+----
+
+You can also include cognitect test runner options:
+
+[source,shell]
+----
+$ bb test:jvm --clj-version 1.9 --namespace-regex '*.sanity.*'
+----
+
+=== Babashka Tests[bb-tests]
+
+To run the entire test suite under Babashka:
+
+[source,shell]
+----
+$ bb test:bb
+----
+
+You can also include cognitect test runner options:
+
+[source,shell]
+----
+$ bb test:bb --var clj-http.lite.integration-test/roundtrip
+----
+
+=== Linting
+
+Our CI workflow lints sources with clj-kondo, and you can too!
+
+[source,shell]
+----
+$ bb lint
+----

--- a/doc/03-maintainer-guide.adoc
+++ b/doc/03-maintainer-guide.adoc
@@ -1,0 +1,19 @@
+= Maintainer Guide
+
+== Introduction
+
+Notes for project maintainers.
+
+== Releasing
+
+The following is *NOT* currently automated:
+
+* reviewing and updating changelog "unreleased" section
+* generating a GitHub release
+
+To release a new version, run `bb publish` which will push a new tag.
+CI will:
+
+* run lint and tests
+* create a thin jar
+* publish the jar to clojars

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,3 +1,6 @@
 {:cljdoc.doc/tree
  [["Readme" {:file "README.md"}]
-  ["Changelog" {:file "CHANGELOG.md"}]]}
+  ["Changelog" {:file "CHANGELOG.md"}]
+  ["User Guide" {:file "doc/01-user-guide.adoc"}]
+  ["Developer Guide" {:file "doc/02-developer-guide.adoc"}]
+  ["Maintainer Guide" {:file "doc/03-maintainer-guide.adoc"}]]}


### PR DESCRIPTION
Also add:
- Credit for contributors (just text for now)
- Interesting alternatives to clj-http-lite
- Info on supported and dev environments
- Dev contributing guidance