### PR TITLE
maint: bump deps (ci and test only)

### DIFF
--- a/.clj-kondo/http-kit/http-kit/config.edn
+++ b/.clj-kondo/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,16 @@
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-channel [{node :node}]
+  (let [[request channel & body] (rest (:children node))]
+    (when-not (and request     channel) (throw (ex-info "No request or channel provided" {})))
+    (when-not (api/token-node? channel) (throw (ex-info "Missing channel argument" {})))
+    (let [new-node
+          (api/list-node
+            (list*
+              (api/token-node 'let)
+              (api/vector-node [channel (api/vector-node [])])
+              request
+              body))]
+
+      {:node new-node})))

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup

--- a/.github/workflows/shared-setup/action.yml
+++ b/.github/workflows/shared-setup/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
     - name: Clojure deps cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
@@ -24,13 +24,13 @@ runs:
         restore-keys: cljdeps-
 
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ inputs.jdk }}
 
     - name: Install Clojure Tools
-      uses: DeLaGuardo/setup-clojure@9.5
+      uses: DeLaGuardo/setup-clojure@12.5
       with:
         cli: 'latest'
         bb: 'latest'
@@ -44,6 +44,7 @@ runs:
         bb --version
         echo "clojure --version"
         clojure --version
+
     - name: Download Clojure Dependencies
       shell: ${{ inputs.shell }}
       run: bb download-deps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup
@@ -29,14 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [{name: 'windows', shell: 'pwsh'}, {name: 'ubuntu', shell: 'bash'}]
-        clojure-version: ["1.8", "1.9", "1.10", "1.11"]
-        jdk: ['8', '11', '17']
+        clojure-version: ["1.8", "1.9", "1.10", "1.11", "1.12"]
+        jdk: ['8', '11', '17', '21']
 
-    name: ${{ matrix.os.name }} clj-${{ matrix.clojure-version }} jdk${{ matrix.java-version }}
+    name: ${{ matrix.os.name }} clj-${{ matrix.clojure-version }} jdk${{ matrix.jdk }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v4
 
       - name: Setup
         uses: ./.github/workflows/shared-setup

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,6 @@
 {:paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
-                           :sha "35ed39645038e81b42cb15ed6753b8462e60a06d"}
+                           :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
         version-clj/version-clj {:mvn/version "2.0.2"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]
@@ -28,9 +28,7 @@
          {:doc "Runs tests under babashka Clojure (recognizes cognitect test-runner args)"
           :extra-paths ["src" "test" "test-resources"]
           :extra-deps {io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-                       org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
-                                                    :git/sha "16b8c53174a5c9d89d6e0ce4128aa30b071aabdf"}}
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
           :requires ([cognitect.test-runner :as tr])
           :task (apply tr/-main *command-line-args*)}
          lint
@@ -44,8 +42,7 @@
           :task publish/-main}
          neil ;; let's not rely on a random version of neil
          {:doc "Pinned version of babashka/neil (used in scripting)"
-          :extra-deps {babashka/neil {:git/url "https://github.com/babashka/neil.git"
-                       :sha "6fc58cc6a4253c2c15f05135f1610ab3d46d961f"}}
+          :extra-deps {io.github.babashka/neil {:git/tag "v0.2.63" :git/sha "076fb83"}}
           :task babashka.neil/-main}
          ;; hidden tasks, no need for folks to be trying these ci invoked tasks
          -ci-clojars-deploy

--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,7 @@
   {:extra-paths ["test" "test-resources"]
    :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
    :extra-deps {babashka/fs {:mvn/version "0.5.20"}
-                ring/ring-jetty-adapter {:mvn/version "1.12.0"}
+                ring/ring-jetty-adapter {:mvn/version "1.10.0"} ;; stick with version that works on jdk8
                 ch.qos.logback/logback-classic {:mvn/version "1.5.3"
                                                 :exclusions [org.slf4j/slf4j-api]}
                 org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,22 +8,23 @@
   :1.8 {:override-deps {org.clojure/clojure {:mvn/version "1.8.0"}}}
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
-  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha9"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:git/tag "v0.8.3" :git/sha "0d20256"}
-          slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.10.0"}
+          slipset/deps-deploy {:mvn/version "0.2.2"}}
    :ns-default build}
   :http-server ;; used for to support integration tests
   {:extra-paths ["test" "test-resources"]
-   :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
-   :extra-deps {babashka/fs {:mvn/version "0.1.6"}
-                ring/ring-jetty-adapter {:mvn/version "1.9.5"}
-                ch.qos.logback/logback-classic {:mvn/version "1.2.11"
+   :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
+   :extra-deps {babashka/fs {:mvn/version "0.5.20"}
+                ring/ring-jetty-adapter {:mvn/version "1.12.0"}
+                ch.qos.logback/logback-classic {:mvn/version "1.5.3"
                                                 :exclusions [org.slf4j/slf4j-api]}
-                org.slf4j/jcl-over-slf4j {:mvn/version "1.7.36"}
-                org.slf4j/jul-to-slf4j {:mvn/version "1.7.36"}
-                org.slf4j/log4j-over-slf4j {:mvn/version "1.7.36"}}
+                org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
+                org.slf4j/jul-to-slf4j {:mvn/version "2.0.12"}
+                org.slf4j/log4j-over-slf4j {:mvn/version "2.0.12"}}
    :exec-fn clj-http.lite.test-util.http-server/run}
   :test
   {:extra-paths ["test"]
@@ -31,6 +32,6 @@
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts ["-m" "cognitect.test-runner"]}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.08.03"}}
-              :override-deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.03.13"}}
+              :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
               :main-opts ["-m" "clj-kondo.main"]}}}

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -23,7 +23,7 @@ We can discuss.
 
 === Supported Environments [[supported-envs]]
 
-* JDK 8, 11, 17
+* JDK 8, 11, 17, 21
 * Clojure 1.8 runtime and above
 * Babashka current release
 * Windows, Linux, macOS

--- a/script/test_jvm.clj
+++ b/script/test_jvm.clj
@@ -4,7 +4,7 @@
             [lread.status-line :as status]))
 
 (defn -main [& args]
-  (let [valid-clojure-versions ["1.8" "1.9" "1.10" "1.11"]
+  (let [valid-clojure-versions ["1.8" "1.9" "1.10" "1.11" "1.12"]
         spec {:clj-version
               {:ref "<version>"
                :desc "The Clojure version to test against."

--- a/test/clj_http/lite/test_util/http_server.clj
+++ b/test/clj_http/lite/test_util/http_server.clj
@@ -67,7 +67,8 @@
                                            :ssl-port     0 ;; Use a free port
                                            :ssl?         true
                                            :keystore     "test-resources/keystore"
-                                           :key-password "keykey"})]
+                                           :key-password "keykey"
+                                           :sni-host-check? false})]
     (println "server started")
     (fs/create-dirs "target")
     (let [ports {:http-port (port-for-protocol s "http/")

--- a/test/clj_http/lite/test_util/http_server.clj
+++ b/test/clj_http/lite/test_util/http_server.clj
@@ -67,8 +67,7 @@
                                            :ssl-port     0 ;; Use a free port
                                            :ssl?         true
                                            :keystore     "test-resources/keystore"
-                                           :key-password "keykey"
-                                           :sni-host-check? false})]
+                                           :key-password "keykey"})]
     (println "server started")
     (fs/create-dirs "target")
     (let [ports {:http-port (port-for-protocol s "http/")


### PR DESCRIPTION
Of note:
- turfed: bb no longer needs https://github.com/babashka/tools.namespace to run tests
- bumping ring-jetty-adapter required small test code change
- now also testing against clojure 1.12
- now also testing against jdk 21