### PR TITLE
test & dev & ci: bump deps, add outdated task

### DIFF
--- a/.clj-kondo/taoensso/encore/config.edn
+++ b/.clj-kondo/taoensso/encore/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}

--- a/.clj-kondo/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/taoensso/encore/taoensso/encore.clj
@@ -1,0 +1,16 @@
+(ns taoensso.encore
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defalias [{:keys [node]}]
+  (let [[sym-raw src-raw] (rest (:children node))
+        src (if src-raw src-raw sym-raw)
+        sym (if src-raw
+              sym-raw
+              (symbol (name (hooks/sexpr src))))]
+    {:node (with-meta
+             (hooks/list-node
+               [(hooks/token-node 'def)
+                (hooks/token-node (hooks/sexpr sym))
+                (hooks/token-node (hooks/sexpr src))])
+             (meta src))}))

--- a/bb.edn
+++ b/bb.edn
@@ -34,6 +34,9 @@
          lint
          {:doc "[--rebuild] Lint source code"
           :task lint/-main}
+         outdated
+         {:doc "Report on outdated dependencies"
+          :task (clojure {:continue true} "-M:outdated")}
          pubcheck
          {:doc "run only publish checks (without publishing)"
           :task publish/pubcheck}
@@ -42,7 +45,7 @@
           :task publish/-main}
          neil ;; let's not rely on a random version of neil
          {:doc "Pinned version of babashka/neil (used in scripting)"
-          :extra-deps {io.github.babashka/neil {:git/tag "v0.2.63" :git/sha "076fb83"}}
+          :extra-deps {io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}}
           :task babashka.neil/-main}
          ;; hidden tasks, no need for folks to be trying these ci invoked tasks
          -ci-clojars-deploy

--- a/deps.edn
+++ b/deps.edn
@@ -8,23 +8,23 @@
   :1.8 {:override-deps {org.clojure/clojure {:mvn/version "1.8.0"}}}
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
-  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha9"}}}
+  :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-alpha11"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:mvn/version "0.10.0"}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.10.3"}
           slipset/deps-deploy {:mvn/version "0.2.2"}}
    :ns-default build}
   :http-server ;; used for to support integration tests
   {:extra-paths ["test" "test-resources"]
-   :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
+   :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
    :extra-deps {babashka/fs {:mvn/version "0.5.20"}
                 ring/ring-jetty-adapter {:mvn/version "1.10.0"} ;; stick with version that works on jdk8
-                ch.qos.logback/logback-classic {:mvn/version "1.5.3"
+                ch.qos.logback/logback-classic {:mvn/version "1.3.14"
                                                 :exclusions [org.slf4j/slf4j-api]}
-                org.slf4j/jcl-over-slf4j {:mvn/version "2.0.12"}
-                org.slf4j/jul-to-slf4j {:mvn/version "2.0.12"}
-                org.slf4j/log4j-over-slf4j {:mvn/version "2.0.12"}}
+                org.slf4j/jcl-over-slf4j {:mvn/version "2.0.13"}
+                org.slf4j/jul-to-slf4j {:mvn/version "2.0.13"}
+                org.slf4j/log4j-over-slf4j {:mvn/version "2.0.13"}}
    :exec-fn clj-http.lite.test-util.http-server/run}
   :test
   {:extra-paths ["test"]
@@ -33,5 +33,15 @@
    :main-opts ["-m" "cognitect.test-runner"]}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.03.13"}}
-              :override-deps {org.clojure/clojure {:mvn/version "1.11.2"}}
-              :main-opts ["-m" "clj-kondo.main"]}}}
+              :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
+              :main-opts ["-m" "clj-kondo.main"]}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1201"}
+                          org.clojure/clojure {:mvn/version "1.11.3"}
+                          org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
+                          }
+             :main-opts ["-m" "antq.core"
+                         "--exclude=ch.qos.logback/logback-classic@1.4.x" ;; requires min jdk 11, we are jdk8 compatible
+                         "--exclude=ch.qos.logback/logback-classic@1.5.x" ;; requires min jdk 11, we are jdk8 compatible
+                         "--exclude=ring/ring-jetty-adapter@1.11.x" ;; requires jdk 11, we are jdk8 compatible
+                         "--exclude=ring/ring-jetty-adapter@1.12.x" ;; requires jdk 11, we are jdk8 compatible
+                         ]}}}


### PR DESCRIPTION
Bump test and build deps (including latest clojure 11 and 12-alpha).

Added an `outdated` task to add some antq configuration to document/express that we don't want to move to any deps that are not jdk8 compatible.

Checked in some 3rd party lib lint config clj-kondo found.