### PR TITLE
test & ci: bump deps, tweak pubcheck

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -45,7 +45,7 @@
           :task publish/-main}
          neil ;; let's not rely on a random version of neil
          {:doc "Pinned version of babashka/neil (used in scripting)"
-          :extra-deps {io.github.babashka/neil {:git/tag "v0.3.65" :git/sha "9a79582"}}
+          :extra-deps {io.github.babashka/neil {:git/tag "v0.3.67" :git/sha "054ca51"}}
           :task babashka.neil/-main}
          ;; hidden tasks, no need for folks to be trying these ci invoked tasks
          -ci-clojars-deploy

--- a/deps.edn
+++ b/deps.edn
@@ -9,10 +9,10 @@
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta2"}}}
   :build
   {:extra-paths ["build"]
-   :deps {io.github.clojure/tools.build {:mvn/version "0.10.4"}
+   :deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
           slipset/deps-deploy {:mvn/version "0.2.2"}}
    :ns-default build}
   :http-server ;; used for to support integration tests
@@ -35,7 +35,7 @@
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
               :main-opts ["-m" "clj-kondo.main"]}
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1201"}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1206"}
                           org.clojure/clojure {:mvn/version "1.11.3"}
                           org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
                           }

--- a/script/publish.clj
+++ b/script/publish.clj
@@ -53,12 +53,15 @@
       string/trim
       seq))
 
+(defn- local-branch? []
+  (let [{:keys [exit]} (t/shell {:continue true :out :string :err :out}
+                                "git rev-parse --symbolic-full-name @{u}")]
+    (not (zero? exit))))
+
 (defn- unpushed-commits? []
   (let [{:keys [exit :out]} (t/shell {:continue true :out :string}
                                      "git cherry -v")]
-    (if (zero? exit)
-      (-> out string/trim seq)
-      (status/die 1 "Failed to check for unpushed commits, are you on an unpushed branch?"))))
+    (and (zero? exit) (-> out string/trim seq))))
 
 (defn- analyze-changelog
   "Certainly not fool proof, but should help for common mistakes"
@@ -87,7 +90,7 @@
      {:check "no uncommitted code"
       :result (if (uncommitted-code?) :fail :pass)}
      {:check "no unpushed commits"
-      :result (if (unpushed-commits?) :fail :pass)}
+      :result (if (or (local-branch?) (unpushed-commits?)) :fail :pass)}
      {:check "changelog has unreleased section"
       :result (if (:section-missing changelog-findings) :fail :pass)}
      {:check "changelog unreleased section attributes valid"


### PR DESCRIPTION
Of note:
- clojure 1.12 beta2!
- bb `pubcheck` task can now run checks on unpushed branch