### PR TITLE
test & ci: bump deps

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,7 @@
 {:paths ["script" "build"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
                            :sha "cf44c15f30ea3867227fa61ceb823e5e942c707f"}
-        version-clj/version-clj {:mvn/version "2.0.2"}}
+        version-clj/version-clj {:mvn/version "2.0.3"}}
  :tasks {;; setup
          :requires ([babashka.fs :as fs]
                     [clojure.string :as string]

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
   :1.9 {:override-deps {org.clojure/clojure {:mvn/version "1.9.0"}}}
   :1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
   :1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
-  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0-beta2"}}}
+  :1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.0"}}}
   :build
   {:extra-paths ["build"]
    :deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
@@ -18,13 +18,13 @@
   :http-server ;; used for to support integration tests
   {:extra-paths ["test" "test-resources"]
    :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
-   :extra-deps {babashka/fs {:mvn/version "0.5.21"}
+   :extra-deps {babashka/fs {:mvn/version "0.5.22"}
                 ring/ring-jetty-adapter {:mvn/version "1.10.0"} ;; stick with version that works on jdk8
                 ch.qos.logback/logback-classic {:mvn/version "1.3.14"
                                                 :exclusions [org.slf4j/slf4j-api]}
-                org.slf4j/jcl-over-slf4j {:mvn/version "2.0.13"}
-                org.slf4j/jul-to-slf4j {:mvn/version "2.0.13"}
-                org.slf4j/log4j-over-slf4j {:mvn/version "2.0.13"}}
+                org.slf4j/jcl-over-slf4j {:mvn/version "2.0.16"}
+                org.slf4j/jul-to-slf4j {:mvn/version "2.0.16"}
+                org.slf4j/log4j-over-slf4j {:mvn/version "2.0.16"}}
    :exec-fn clj-http.lite.test-util.http-server/run}
   :test
   {:extra-paths ["test"]
@@ -32,12 +32,12 @@
                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
    :main-opts ["-m" "cognitect.test-runner"]}
   ;; for consistent linting we use a specific version of clj-kondo through the jvm
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.05.24"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.29"}}
               :override-deps {org.clojure/clojure {:mvn/version "1.11.3"}}
               :main-opts ["-m" "clj-kondo.main"]}
-  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.8.1206"}
+  :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version  "2.9.1221"}
                           org.clojure/clojure {:mvn/version "1.11.3"}
-                          org.slf4j/slf4j-simple {:mvn/version "2.0.13"} ;; to rid ourselves of logger warnings
+                          org.slf4j/slf4j-simple {:mvn/version "2.0.16"} ;; to rid ourselves of logger warnings
                           }
              :main-opts ["-m" "antq.core"
                          "--exclude=ch.qos.logback/logback-classic@1.4.x" ;; requires min jdk 11, we are jdk8 compatible

--- a/script/lint.clj
+++ b/script/lint.clj
@@ -23,10 +23,8 @@
                    with-out-str
                    string/trim)
         bb-cp (bbcp/get-classpath)]
-    (status/line :detail "- copying configs")
-    (t/clojure "-M:clj-kondo --skip-lint --copy-configs --lint" clj-cp bb-cp)
-    (status/line :detail "- creating cache")
-    (t/clojure "-M:clj-kondo --dependencies --lint" clj-cp bb-cp)))
+    (status/line :detail "- copying lib configs and creating cache")
+    (t/clojure "-M:clj-kondo  --skip-lint --copy-configs --dependencies --lint" clj-cp bb-cp)))
 
 (defn- check-cache [{:keys [rebuild]}]
   (status/line :head "clj-kondo: cache check")
@@ -50,7 +48,7 @@
   (status/line :head "clj-kondo: linting")
   (let [{:keys [exit]}
         (t/clojure {:continue true}
-                   "-M:clj-kondo --lint src test build script deps.edn bb.edn")]
+                   "-M:clj-kondo --parallel --lint src test build script deps.edn bb.edn")]
     (cond
       (= 2 exit) (status/die exit "clj-kondo found one or more lint errors")
       (= 3 exit) (status/die exit "clj-kondo found one or more lint warnings")


### PR DESCRIPTION
Of note:
- clojure 1.12.0! woot!
- new version of clj-kondo - we can now build cache and copy configs in one step